### PR TITLE
reside-64: allow replacement of many keys in one block of text

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,8 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 Imports:
     V8,
-    R6
+    R6,
+    glue
 Suggests:
     jsonlite,
     knitr,

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -37,13 +37,7 @@ R6_i18n <- R6::R6Class(
     },
 
     replace = function(text) {
-      res <- glue::glue(text,
-                        .transformer = i18n_transformer(self),
-                        .open = "t_(", .close = ")")
-      ## glue leaves a 'glue' class here, which we don't need or want,
-      ## and it's not obviously documented what that class is actually
-      ## *for*.
-      unclass(res)
+      vapply(text, i18n_replace1, "", self, USE.NAMES = !is.null(names(text)))
     },
 
     exists = function(string, data = NULL, language = NULL, count = NULL,
@@ -110,4 +104,15 @@ i18n_transformer <- function(i18n) {
   function(text, envir) {
     i18n$t(text)
   }
+}
+
+
+i18n_replace1 <- function(text, i18n) {
+  res <- glue::glue(text,
+                    .transformer = i18n_transformer(i18n),
+                    .open = "t_(", .close = ")")
+  ## glue leaves a 'glue' class here, which we don't need or want,
+  ## and it's not obviously documented what that class is actually
+  ## *for*.
+  unclass(res)
 }

--- a/inst/examples/simple.json
+++ b/inst/examples/simple.json
@@ -2,6 +2,7 @@
     "en": {
         "translation": {
             "hello": "hello world",
+            "query": "how are you?",
             "interpolate": "{{what}} is {{how}}",
             "pluralex1": "nose",
             "pluralex1_plural": "noses",
@@ -12,6 +13,7 @@
     "fr": {
         "translation": {
             "hello": "bonjour le monde",
+            "query": "ça va ?",
             "interpolate": "{{what}} est {{how}}",
             "pluralex1": "nez",
             "pluralex1_plural": "nez",

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -85,6 +85,8 @@ test_that("replace", {
   expect_equal(obj$replace(str), '{"greeting": "hello world"}')
   obj$set_language("fr")
   expect_equal(obj$replace(str), '{"greeting": "bonjour le monde"}')
+  expect_equal(obj$replace(str, language = "en"),
+               '{"greeting": "hello world"}')
 })
 
 

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -86,3 +86,27 @@ test_that("replace", {
   obj$set_language("fr")
   expect_equal(obj$replace(str), '{"greeting": "bonjour le monde"}')
 })
+
+
+test_that("replace works on multiline strings", {
+  obj <- i18n(traduire_file("examples/simple.json"))
+  obj$set_language("fr")
+  str <- c("{",
+           '  "x": "t_(hello)",',
+           '  "y": "t_(query)"',
+           "}")
+  expected <- c("{",
+                '  "x": "bonjour le monde",',
+                '  "y": "ça va ?"',
+                "}")
+  expect_equal(obj$replace(str), expected)
+})
+
+
+test_that("replace retains names on multiline strings", {
+  obj <- i18n(traduire_file("examples/simple.json"))
+  x <- c(a = "t_(hello)", b = "t_(query)")
+  y <- c(a = "hello world", b = "how are you?")
+  expect_equal(obj$replace(x), y)
+  expect_equal(obj$replace(unname(x)), unname(y))
+})

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -77,3 +77,12 @@ test_that("context", {
   expect_equal(obj$t("house", context = "small", count = 1), "A cottage")
   expect_equal(obj$t("house", context = "small", count = 3), "3 cottages")
 })
+
+
+test_that("replace", {
+  obj <- i18n(traduire_file("examples/simple.json"))
+  str <- '{"greeting": "t_(hello)"}'
+  expect_equal(obj$replace(str), '{"greeting": "hello world"}')
+  obj$set_language("fr")
+  expect_equal(obj$replace(str), '{"greeting": "bonjour le monde"}')
+})


### PR DESCRIPTION
This is designed to address the use-case not covered by #3, where we want to bulk-replace keys in an input json file.

For the json case, one option would be to traverse the json directly in js, but I think this approach will be as nice, and work for other use-cases too.

The idea is that the `i18n` object gets a `replace` method, which will translate all strings surrounded by `t_(...)`, using the machinery in glue. We might need to make the surrounding strings tuneable in future, but I'm not totally how robust glue's parser is or how one might escape keys.  However, `t_(` is fairly unlikely as a string, and keys can't/shouldn't contain `)` so let's see.