### PR TITLE
reside-67: load resources at runtime, split by namespace

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,4 +4,4 @@
 ^\.travis\.yml$
 ^docs$
 ^js$
-^\.V8history$
+\.V8history$

--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -4,3 +4,4 @@
 ^\.travis\.yml$
 ^docs$
 ^js$
+^\.V8history$

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ js/bundle*js
 inst/doc
 vignettes/*.html
 vignettes/*.R
+.V8history

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -125,11 +125,11 @@ R6_i18n <- R6::R6Class(
       private$context$call("i18next.hasResourceBundle", language, namespace)
     },
 
-    add_resource_bundle = function(language, namespace, bundle,
+    add_resource_bundle = function(language, namespace, resources,
                                    deep = FALSE, overwrite = FALSE) {
-      bundle_js <- read_input(bundle)
-      private$context$call("i18next.addResourceBundle",
-                           language, namespace, bundle_js, deep, overwrite)
+      resources_js <- read_input(resources)
+      private$context$call("addResourceBundle",
+                           language, namespace, resources_js, deep, overwrite)
       invisible(self)
     },
 

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -27,17 +27,26 @@
 ##'   translation resources.  Only works if \code{translations} is
 ##'   \code{NULL} at present.
 ##'
+##' @param namespaces A vector of namespaces to load. Namespaces not
+##'   listed here may not be loaded as expected (use \code{debug =
+##'   TRUE} to work out what is going on).  The default (\code{NULL})
+##'   will use i18next's logic, which is to use \code{translation} as
+##'   the only loaded namespace.  This creates some issues if
+##'   \code{default_namespace} is set here, as the default namespace
+##'   will not be loaded.  A future version of this package will
+##'   probably do better with the logic here.
+##'
 ##' @export
 ##' @examples
 ##' path <- system.file("examples/simple.json", package = "traduire")
 ##' obj <- traduire::i18n(path)
 ##' obj$t("hello", language = "fr")
 i18n <- function(resources, language = NULL, default_namespace = NULL,
-                 debug = FALSE, resource_pattern = NULL) {
-  ## TODO: better defaults here, but there's lots to consider with
-  ## fallbacks still
+                 debug = FALSE, resource_pattern = NULL, namespaces = NULL) {
+  ## TODO: better defaults for language, but there's lots to consider
+  ## with fallbacks still
   R6_i18n$new(resources, language %||% "en", default_namespace,
-              debug, resource_pattern)
+              debug, resource_pattern, namespaces)
 }
 
 
@@ -52,12 +61,13 @@ R6_i18n <- R6::R6Class(
 
   public = list(
     initialize = function(resources, language, default_namespace,
-                          debug, resource_pattern) {
+                          debug, resource_pattern, namespaces) {
       resources_js <- read_input(resources)
       private$context <- V8::v8()
       private$context$source(traduire_file("js/bundle.js"))
       private$context$call("init", resources_js, language,
-                           default_namespace, debug, resource_pattern)
+                           default_namespace, debug, resource_pattern,
+                           namespaces)
     },
 
     t = function(string, data = NULL, language = NULL, count = NULL,

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -111,6 +111,11 @@ R6_i18n <- R6::R6Class(
     load_namespaces = function(namespaces) {
       private$context$call("i18next.loadNamespaces", namespaces)
       invisible(self)
+    },
+
+    load_languages = function(languages) {
+      private$context$call("i18next.loadLanguages", languages)
+      invisible(self)
     }
   )
 )

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -68,6 +68,16 @@ R6_i18n <- R6::R6Class(
 
     languages = function() {
       private$context$call("languages")
+    },
+
+    default_namespace = function() {
+      private$context$call("default_namespace")
+    },
+
+    set_default_namespace = function(namespace) {
+      prev <- self$default_namespace()
+      private$context$call("i18next.setDefaultNamespace", namespace)
+      invisible(function() self$set_default_namespace(prev))
     }
   )
 )

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -61,8 +61,7 @@ R6_i18n <- R6::R6Class(
 
   cloneable = FALSE,
   private = list(
-    context = NULL,
-    address = NULL
+    context = NULL
   ),
 
   public = list(

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -1,16 +1,23 @@
 ##' Create a new translator object
 ##' @title Create translator object
+##'
 ##' @param translations Path to a json file containing translations
+##'
 ##' @param language The default language for the translation
+##'
+##' @param default_namespace The default namespace to use.  If not
+##'   given, then \code{i18next} assumes the namespace
+##'   \code{translation}
+##'
 ##' @export
 ##' @examples
 ##' path <- system.file("examples/simple.json", package = "traduire")
 ##' obj <- traduire::i18n(path)
 ##' obj$t("hello", language = "fr")
-i18n <- function(translations, language = NULL) {
+i18n <- function(translations, language = NULL, default_namespace = NULL) {
   ## TODO: better defaults here, but there's lots to consider with
   ## fallbacks still
-  R6_i18n$new(translations, language %||% "en")
+  R6_i18n$new(translations, language %||% "en", default_namespace)
 }
 
 
@@ -23,11 +30,11 @@ R6_i18n <- R6::R6Class(
   ),
 
   public = list(
-    initialize = function(translations, language) {
+    initialize = function(translations, language, default_namespace) {
       translations_js <- read_input(translations)
       private$context <- V8::v8()
       private$context$source(traduire_file("js/bundle.js"))
-      private$context$call("init", translations_js, language)
+      private$context$call("init", translations_js, language, default_namespace)
     },
 
     t = function(string, data = NULL, language = NULL, count = NULL,

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -36,17 +36,23 @@
 ##'   will not be loaded.  A future version of this package will
 ##'   probably do better with the logic here.
 ##'
+##' @param languages A vector of languages to \emph{preload}. You can
+##'   always add additional languages using the \code{load_language}
+##'   method.  Note that the adding a language here does not (yet)
+##'   mean that failure to load the language is an error.
+##'
 ##' @export
 ##' @examples
 ##' path <- system.file("examples/simple.json", package = "traduire")
 ##' obj <- traduire::i18n(path)
 ##' obj$t("hello", language = "fr")
 i18n <- function(resources, language = NULL, default_namespace = NULL,
-                 debug = FALSE, resource_pattern = NULL, namespaces = NULL) {
+                 debug = FALSE, resource_pattern = NULL, namespaces = NULL,
+                 languages = NULL) {
   ## TODO: better defaults for language, but there's lots to consider
   ## with fallbacks still
   R6_i18n$new(resources, language %||% "en", default_namespace,
-              debug, resource_pattern, namespaces)
+              debug, resource_pattern, namespaces, languages)
 }
 
 
@@ -61,13 +67,13 @@ R6_i18n <- R6::R6Class(
 
   public = list(
     initialize = function(resources, language, default_namespace,
-                          debug, resource_pattern, namespaces) {
+                          debug, resource_pattern, namespaces, languages) {
       resources_js <- read_input(resources)
       private$context <- V8::v8()
       private$context$source(traduire_file("js/bundle.js"))
       private$context$call("init", resources_js, language,
                            default_namespace, debug, resource_pattern,
-                           namespaces)
+                           namespaces, languages)
     },
 
     t = function(string, data = NULL, language = NULL, count = NULL,

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -47,8 +47,8 @@
 ##' obj <- traduire::i18n(path)
 ##' obj$t("hello", language = "fr")
 i18n <- function(resources, language = NULL, default_namespace = NULL,
-                 debug = FALSE, resource_pattern = NULL, namespaces = NULL,
-                 languages = NULL) {
+                 debug = FALSE, resource_pattern = NULL,
+                 namespaces = NULL, languages = NULL) {
   ## TODO: better defaults for language, but there's lots to consider
   ## with fallbacks still
   R6_i18n$new(resources, language %||% "en", default_namespace,
@@ -72,8 +72,11 @@ R6_i18n <- R6::R6Class(
       private$context <- V8::v8()
       private$context$source(traduire_file("js/bundle.js"))
       private$context$call("init", resources_js, language,
-                           default_namespace, debug, resource_pattern,
-                           namespaces, languages)
+                           safe_js_null(default_namespace),
+                           debug,
+                           safe_js_null(resource_pattern),
+                           namespaces %||% "translation",
+                           safe_js_null(languages))
     },
 
     t = function(string, data = NULL, language = NULL, count = NULL,

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -190,9 +190,11 @@ i18n_backend_read <- function(pattern, language, namespace) {
   tryCatch(
     read_input(path),
     error = function(e) {
-      message(sprintf(
-        "Tried to load language:%s, namespace:%s but failed (%s)",
-        language, namespace, e$message))
+      if (language != "dev") {
+        message(sprintf(
+          "Tried to load language:%s, namespace:%s but failed (%s)",
+          language, namespace, e$message))
+      }
       return(jsonlite::unbox("null"))
     })
 }

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -1,4 +1,11 @@
 ##' Create a new translator object
+##'
+##' @section Warning:
+##'
+##' Note that the argument list here \emph{will} change.  The only
+##'   part of this that we consider stable is that the first argument
+##'   will represent a resource bundle.
+##'
 ##' @title Create translator object
 ##'
 ##' @param resources Path to a json file containing translation

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -78,6 +78,18 @@ R6_i18n <- R6::R6Class(
       prev <- self$default_namespace()
       private$context$call("i18next.setDefaultNamespace", namespace)
       invisible(function() self$set_default_namespace(prev))
+    },
+
+    has_resource_bundle = function(language, namespace) {
+      private$context$call("i18next.hasResourceBundle", language, namespace)
+    },
+
+    add_resource_bundle = function(language, namespace, bundle,
+                                   deep = FALSE, overwrite = FALSE) {
+      bundle_js <- read_input(bundle)
+      private$context$call("i18next.addResourceBundle",
+                           language, namespace, bundle_js, deep, overwrite)
+      invisible(self)
     }
   )
 )

--- a/R/translator.R
+++ b/R/translator.R
@@ -48,9 +48,9 @@
 ##' traduire::translator_register(path, name = "myexample")
 ##' traduire::t_("hello", language = "fr", name = "myexample")
 ##' traduire::translator_unregister("myexample")
-translator_register <- function(translations, language = NULL, name = NULL) {
+translator_register <- function(resources, language = NULL, name = NULL) {
   name <- name_from_context(name)
-  translators[[name]] <- i18n(translations, language)
+  translators[[name]] <- i18n(resources, language)
 }
 
 

--- a/R/util.R
+++ b/R/util.R
@@ -17,7 +17,9 @@ read_file <- function(path) {
 ## always want a path to the input?
 read_input <- function(x, name = deparse(substitute(x))) {
   if (is.null(x)) {
-    return(V8::JS("{}"))
+    ## This might need to be tuneable - for the initial load we need a
+    ## null at least.
+    return(jsonlite::unbox("null"))
   }
   if (read_input_is_filename(x)) {
     if (!file.exists(x)) {
@@ -26,7 +28,12 @@ read_input <- function(x, name = deparse(substitute(x))) {
     }
     x <- read_file(x)
   }
-  V8::JS(x)
+
+  tryCatch(
+    jsonlite::fromJSON(x),
+    error = function(e) stop("Failed to parse json input: ", e$message))
+
+  jsonlite::unbox(x)
 }
 
 

--- a/R/util.R
+++ b/R/util.R
@@ -41,3 +41,11 @@ read_input_is_filename <- function(x) {
   RE_JSON <- "[{['\"]"
   !(length(x) != 1 || inherits(x, "AsIs") || grepl(RE_JSON, x))
 }
+
+
+safe_js_null <- function(x) {
+  if (is.null(x)) {
+    return(V8::JS("null"))
+  }
+  x
+}

--- a/R/util.R
+++ b/R/util.R
@@ -16,6 +16,9 @@ read_file <- function(path) {
 ## Same logic as jsonvalidate, possibly overkill here. Perhaps we
 ## always want a path to the input?
 read_input <- function(x, name = deparse(substitute(x))) {
+  if (is.null(x)) {
+    return(V8::JS("{}"))
+  }
   if (read_input_is_filename(x)) {
     if (!file.exists(x)) {
       stop(sprintf("'%s' looks like a filename but does not exist", name),

--- a/inst/examples/namespaces.json
+++ b/inst/examples/namespaces.json
@@ -1,0 +1,20 @@
+{
+    "en": {
+        "common": {
+            "hello": "hello world"
+        },
+        "login": {
+            "username": "Username",
+            "password": "Password"
+        }
+    },
+    "fr": {
+        "common": {
+            "hello": "salut le monde"
+        },
+        "login": {
+            "username": "Nom d'utilisateur",
+            "password": "Mot de passe"
+        }
+    }
+}

--- a/inst/examples/structured/en-common.json
+++ b/inst/examples/structured/en-common.json
@@ -1,0 +1,3 @@
+{
+    "hello": "hello world"
+}

--- a/inst/examples/structured/en-login.json
+++ b/inst/examples/structured/en-login.json
@@ -1,0 +1,4 @@
+{
+    "username": "Username",
+    "password": "Password"
+}

--- a/inst/examples/structured/fr-common.json
+++ b/inst/examples/structured/fr-common.json
@@ -1,0 +1,3 @@
+{
+    "hello": "salut le monde"
+}

--- a/inst/examples/structured/fr-login.json
+++ b/inst/examples/structured/fr-login.json
@@ -1,0 +1,4 @@
+{
+    "username": "Nom d'utilisateur",
+    "password": "Mot de passe"
+}

--- a/inst/examples/validation.json
+++ b/inst/examples/validation.json
@@ -2,7 +2,7 @@
     "en": {
         "translation": {
             "nocols": "Data missing column {{missing}}",
-            "nocols_plural": "Data missing columns {{missing}}",
+            "nocols_plural": "Data missing columns {{missing}}"
         }
     },
 

--- a/inst/hello/R/api.R
+++ b/inst/hello/R/api.R
@@ -22,7 +22,7 @@ api_set_language <- function(data, req, res) {
 ## And this wll be used to reset it to whatever was used at the start
 ## of the request.
 api_reset_language <- function(data, req, res, value) {
-  if (!is.null(data$reset)) {
+  if (!is.null(data$reset_language)) {
     data$reset_language()
   }
   value

--- a/inst/js/bundle.js
+++ b/inst/js/bundle.js
@@ -9,12 +9,15 @@ global.Promise = require("promise");
 global.i18next = require("i18next");
 global.i18next_sprintf = require("i18next-sprintf-postprocessor");
 
-global.init = function(resources, lng) {
+global.init = function(resources, lng, defaultNS) {
     var options = {
         "lng": lng,
         "resources": resources,
         "initImmediate": true
     };
+    if (defaultNS) {
+        options.defaultNS = defaultNS;
+    }
     global.i18next
         .use(i18next_sprintf)
         .init(options);

--- a/inst/js/bundle.js
+++ b/inst/js/bundle.js
@@ -40,6 +40,10 @@ global.languages = function() {
     return i18next.languages;
 }
 
+global.default_namespace = function() {
+    return i18next.options.defaultNS;
+};
+
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
 },{"i18next":25,"i18next-sprintf-postprocessor":24,"promise":26}],2:[function(require,module,exports){
 function _arrayWithHoles(arr) {

--- a/inst/js/bundle.js
+++ b/inst/js/bundle.js
@@ -13,7 +13,7 @@ global.Promise = require("promise");
 global.i18next = require("i18next");
 
 global.init = function(resources, lng, defaultNS, debug, resourcePattern,
-                       namespaces) {
+                       namespaces, languages) {
     var options = {
         "lng": lng,
         // it's important that 'resources' comes through as null, not
@@ -25,6 +25,7 @@ global.init = function(resources, lng, defaultNS, debug, resourcePattern,
         "debug": debug,
         "initImmediate": true,
         "ns": namespaces,
+        "preload": languages,
         "backend": {
             "resourcePattern": resourcePattern
         }

--- a/inst/js/bundle.js
+++ b/inst/js/bundle.js
@@ -59,6 +59,10 @@ global.default_namespace = function() {
     return i18next.options.defaultNS;
 };
 
+global.addResourceBundle = function(lng, ns, resources, deep, overwrite) {
+    i18next.addResourceBundle(lng, ns, JSON.parse(resources), deep, overwrite);
+}
+
 global.traduireLoader = function() {
     return {
         type: 'backend',

--- a/inst/js/bundle.js
+++ b/inst/js/bundle.js
@@ -12,17 +12,19 @@ global.Promise = require("promise");
 
 global.i18next = require("i18next");
 
-global.init = function(resources, lng, defaultNS, debug, resourcePattern) {
+global.init = function(resources, lng, defaultNS, debug, resourcePattern,
+                       namespaces) {
     var options = {
         "lng": lng,
-        // it's important that this comes through as null, not as {},
-        // if resources are not available or load won't be
+        // it's important that 'resources' comes through as null, not
+        // as {}, if resources are not available or load won't be
         // triggered...that probably needs dealing with somewhere - I
         // think that the option partialBundledLanguages is important
         // here?
         "resources": JSON.parse(resources),
         "debug": debug,
         "initImmediate": true,
+        "ns": namespaces,
         "backend": {
             "resourcePattern": resourcePattern
         }

--- a/js/in.js
+++ b/js/in.js
@@ -10,17 +10,19 @@ global.Promise = require("promise");
 
 global.i18next = require("i18next");
 
-global.init = function(resources, lng, defaultNS, debug, resourcePattern) {
+global.init = function(resources, lng, defaultNS, debug, resourcePattern,
+                       namespaces) {
     var options = {
         "lng": lng,
-        // it's important that this comes through as null, not as {},
-        // if resources are not available or load won't be
+        // it's important that 'resources' comes through as null, not
+        // as {}, if resources are not available or load won't be
         // triggered...that probably needs dealing with somewhere - I
         // think that the option partialBundledLanguages is important
         // here?
         "resources": JSON.parse(resources),
         "debug": debug,
         "initImmediate": true,
+        "ns": namespaces,
         "backend": {
             "resourcePattern": resourcePattern
         }

--- a/js/in.js
+++ b/js/in.js
@@ -37,3 +37,7 @@ global.language = function() {
 global.languages = function() {
     return i18next.languages;
 }
+
+global.default_namespace = function() {
+    return i18next.options.defaultNS;
+};

--- a/js/in.js
+++ b/js/in.js
@@ -57,6 +57,10 @@ global.default_namespace = function() {
     return i18next.options.defaultNS;
 };
 
+global.addResourceBundle = function(lng, ns, resources, deep, overwrite) {
+    i18next.addResourceBundle(lng, ns, JSON.parse(resources), deep, overwrite);
+}
+
 global.traduireLoader = function() {
     return {
         type: 'backend',

--- a/js/in.js
+++ b/js/in.js
@@ -11,7 +11,7 @@ global.Promise = require("promise");
 global.i18next = require("i18next");
 
 global.init = function(resources, lng, defaultNS, debug, resourcePattern,
-                       namespaces) {
+                       namespaces, languages) {
     var options = {
         "lng": lng,
         // it's important that 'resources' comes through as null, not
@@ -23,6 +23,7 @@ global.init = function(resources, lng, defaultNS, debug, resourcePattern,
         "debug": debug,
         "initImmediate": true,
         "ns": namespaces,
+        "preload": languages,
         "backend": {
             "resourcePattern": resourcePattern
         }

--- a/js/in.js
+++ b/js/in.js
@@ -7,12 +7,15 @@ global.Promise = require("promise");
 global.i18next = require("i18next");
 global.i18next_sprintf = require("i18next-sprintf-postprocessor");
 
-global.init = function(resources, lng) {
+global.init = function(resources, lng, defaultNS) {
     var options = {
         "lng": lng,
         "resources": resources,
         "initImmediate": true
     };
+    if (defaultNS) {
+        options.defaultNS = defaultNS;
+    }
     global.i18next
         .use(i18next_sprintf)
         .init(options);

--- a/js/package.json
+++ b/js/package.json
@@ -17,10 +17,10 @@
     "url": "https://github.com/reside-ic/i18next/issues"
   },
   "homepage": "https://github.com/reside-ic/i18next#readme",
-    "dependencies": {
-      "browserify": "^16.5.0",
-      "i18next": "^19.0.0",
-      "i18next-sprintf-postprocessor": "^0.2.2",
-      "promise": "^8.0.0"
+  "dependencies": {
+    "browserify": "^16.5.0",
+    "i18next": "^19.0.0",
+    "i18next-sprintf-postprocessor": "^0.2.2",
+    "promise": "^8.0.0"
   }
 }

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -35,6 +35,14 @@ translation resources.  Only works if \code{translations} is
 \description{
 Create a new translator object
 }
+\section{Warning}{
+
+
+Note that the argument list here \emph{will} change.  The only
+  part of this that we consider stable is that the first argument
+  will represent a resource bundle.
+}
+
 \examples{
 path <- system.file("examples/simple.json", package = "traduire")
 obj <- traduire::i18n(path)

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -4,12 +4,16 @@
 \alias{i18n}
 \title{Create translator object}
 \usage{
-i18n(translations, language = NULL)
+i18n(translations, language = NULL, default_namespace = NULL)
 }
 \arguments{
 \item{translations}{Path to a json file containing translations}
 
 \item{language}{The default language for the translation}
+
+\item{default_namespace}{The default namespace to use.  If not
+given, then \code{i18next} assumes the namespace
+\code{translation}}
 }
 \description{
 Create a new translator object

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -9,7 +9,8 @@ i18n(
   language = NULL,
   default_namespace = NULL,
   debug = FALSE,
-  resource_pattern = NULL
+  resource_pattern = NULL,
+  namespaces = NULL
 )
 }
 \arguments{
@@ -31,6 +32,15 @@ be turned on.  This will result in lots of output via
 \item{resource_pattern}{A pattern to use for on-demand loading of
 translation resources.  Only works if \code{translations} is
 \code{NULL} at present.}
+
+\item{namespaces}{A vector of namespaces to load. Namespaces not
+listed here may not be loaded as expected (use \code{debug =
+TRUE} to work out what is going on).  The default (\code{NULL})
+will use i18next's logic, which is to use \code{translation} as
+the only loaded namespace.  This creates some issues if
+\code{default_namespace} is set here, as the default namespace
+will not be loaded.  A future version of this package will
+probably do better with the logic here.}
 }
 \description{
 Create a new translator object

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -10,7 +10,8 @@ i18n(
   default_namespace = NULL,
   debug = FALSE,
   resource_pattern = NULL,
-  namespaces = NULL
+  namespaces = NULL,
+  languages = NULL
 )
 }
 \arguments{
@@ -41,6 +42,11 @@ the only loaded namespace.  This creates some issues if
 \code{default_namespace} is set here, as the default namespace
 will not be loaded.  A future version of this package will
 probably do better with the logic here.}
+
+\item{languages}{A vector of languages to \emph{preload}. You can
+always add additional languages using the \code{load_language}
+method.  Note that the adding a language here does not (yet)
+mean that failure to load the language is an error.}
 }
 \description{
 Create a new translator object

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -4,16 +4,33 @@
 \alias{i18n}
 \title{Create translator object}
 \usage{
-i18n(translations, language = NULL, default_namespace = NULL)
+i18n(
+  resources,
+  language = NULL,
+  default_namespace = NULL,
+  debug = FALSE,
+  resource_pattern = NULL
+)
 }
 \arguments{
-\item{translations}{Path to a json file containing translations}
+\item{resources}{Path to a json file containing translation
+resources. If given in this way, then on-demand translation
+loading (via \code{resource_pattern}) is disabled unless a
+currently unexposed i18next option is used.}
 
 \item{language}{The default language for the translation}
 
 \item{default_namespace}{The default namespace to use.  If not
 given, then \code{i18next} assumes the namespace
 \code{translation}}
+
+\item{debug}{Logical, indicating if i18next's debug output should
+be turned on.  This will result in lots of output via
+\code{message} about various i18next actions.}
+
+\item{resource_pattern}{A pattern to use for on-demand loading of
+translation resources.  Only works if \code{translations} is
+\code{NULL} at present.}
 }
 \description{
 Create a new translator object

--- a/man/translator.Rd
+++ b/man/translator.Rd
@@ -9,7 +9,7 @@
 \alias{translator_set_language}
 \title{Register a translator}
 \usage{
-translator_register(translations, language = NULL, name = NULL)
+translator_register(resources, language = NULL, name = NULL)
 
 translator_unregister(name = NULL)
 
@@ -22,7 +22,10 @@ translator(name = NULL)
 translator_set_language(language, name = NULL)
 }
 \arguments{
-\item{translations}{Path to a json file containing translations}
+\item{resources}{Path to a json file containing translation
+resources. If given in this way, then on-demand translation
+loading (via \code{resource_pattern}) is disabled unless a
+currently unexposed i18next option is used.}
 
 \item{language}{Language to use, passed through to
 \code{\link{i18n}}'s \code{set_language} method}

--- a/tests/testthat/test-backend.R
+++ b/tests/testthat/test-backend.R
@@ -38,3 +38,21 @@ test_that("predeclare namespaces", {
   expect_equal(obj$t("common:hello", language = "fr"), "salut le monde")
   expect_equal(obj$t("login:username", language = "fr"), "Nom d'utilisateur")
 })
+
+
+test_that("predeclare namespaces & languages", {
+  pattern <- file.path(
+    traduire_file("examples/structured"),
+    "{language}-{namespace}.json")
+  obj <- i18n(NULL, debug = FALSE, resource_pattern = pattern,
+              default_namespace = "common", namespaces = c("common", "login"),
+              languages = c("en", "fr"))
+
+  expect_equal(obj$t("hello"), "hello world")
+  expect_equal(obj$t("common:hello"), "hello world")
+  expect_equal(obj$t("login:username"), "Username")
+
+  expect_equal(obj$t("hello", language = "fr"), "salut le monde")
+  expect_equal(obj$t("common:hello", language = "fr"), "salut le monde")
+  expect_equal(obj$t("login:username", language = "fr"), "Nom d'utilisateur")
+})

--- a/tests/testthat/test-backend.R
+++ b/tests/testthat/test-backend.R
@@ -1,0 +1,12 @@
+context("backend")
+
+test_that("basic backend loading works", {
+  pattern <- file.path(
+    traduire_file("examples/structured"),
+    "{language}-{namespace}.json")
+
+  obj <- i18n(NULL, debug = FALSE, resource_pattern = pattern)
+  expect_equal(obj$t("common:hello"), "hello")
+  obj$load_namespaces("common")
+  expect_equal(obj$t("common:hello", language = "en"), "hello world")
+})

--- a/tests/testthat/test-backend.R
+++ b/tests/testthat/test-backend.R
@@ -7,6 +7,11 @@ test_that("basic backend loading works", {
 
   obj <- i18n(NULL, debug = FALSE, resource_pattern = pattern)
   expect_equal(obj$t("common:hello"), "hello")
+  expect_equal(obj$t("common:hello", language = "fr"), "hello")
   obj$load_namespaces("common")
   expect_equal(obj$t("common:hello", language = "en"), "hello world")
+  expect_equal(obj$t("common:hello", language = "fr"), "hello")
+  obj$load_languages("fr")
+  expect_equal(obj$t("common:hello", language = "en"), "hello world")
+  expect_equal(obj$t("common:hello", language = "fr"), "salut le monde")
 })

--- a/tests/testthat/test-backend.R
+++ b/tests/testthat/test-backend.R
@@ -15,3 +15,26 @@ test_that("basic backend loading works", {
   expect_equal(obj$t("common:hello", language = "en"), "hello world")
   expect_equal(obj$t("common:hello", language = "fr"), "salut le monde")
 })
+
+
+test_that("predeclare namespaces", {
+  pattern <- file.path(
+    traduire_file("examples/structured"),
+    "{language}-{namespace}.json")
+  obj <- i18n(NULL, debug = FALSE, resource_pattern = pattern,
+              default_namespace = "common", namespaces = c("common", "login"))
+
+  expect_equal(obj$t("hello"), "hello world")
+  expect_equal(obj$t("common:hello"), "hello world")
+  expect_equal(obj$t("login:username"), "Username")
+
+  expect_equal(obj$t("hello", language = "fr"), "hello")
+  expect_equal(obj$t("common:hello", language = "fr"), "hello")
+  expect_equal(obj$t("login:username", language = "fr"), "username")
+
+  obj$load_languages("fr")
+
+  expect_equal(obj$t("hello", language = "fr"), "salut le monde")
+  expect_equal(obj$t("common:hello", language = "fr"), "salut le monde")
+  expect_equal(obj$t("login:username", language = "fr"), "Nom d'utilisateur")
+})

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -116,3 +116,28 @@ test_that("replace retains names on multiline strings", {
   expect_equal(obj$replace(x), y)
   expect_equal(obj$replace(unname(x)), unname(y))
 })
+
+
+test_that("can access keys in different namespaces", {
+  ## TODO: t("hello") is not great here if the default namespace is
+  ## not set.
+  obj <- i18n(traduire_file("examples/namespaces.json"),
+              default_namespace = "common")
+  expect_equal(obj$t("hello"), "hello world")
+  expect_equal(obj$t("common:hello"), "hello world")
+  expect_equal(obj$t("login:username"), "Username")
+})
+
+
+test_that("can set default namespace, and reset it later", {
+  obj <- i18n(traduire_file("examples/namespaces.json"),
+              default_namespace = "common")
+  expect_equal(obj$default_namespace(), "common")
+  res <- withVisible(
+    obj$set_default_namespace("login"))
+  expect_is(res$value, "function")
+  expect_false(res$visible)
+  expect_equal(obj$default_namespace(), "login")
+  res$value()
+  expect_equal(obj$default_namespace(), "common")
+})

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -161,12 +161,14 @@ test_that("load resource bundles", {
                           traduire_file("examples/structured/en-login.json"))
   obj$add_resource_bundle("fr", "common",
                           traduire_file("examples/structured/fr-common.json"))
+
   expect_true(obj$has_resource_bundle("en", "common"))
   expect_true(obj$has_resource_bundle("en", "login"))
   expect_true(obj$has_resource_bundle("fr", "common"))
   expect_false(obj$has_resource_bundle("fr", "login"))
+
   expect_equal(obj$t("hello"), "hello world")
   expect_equal(obj$t("hello", language = "fr"), "salut le monde")
   expect_equal(obj$t("login:username"), "Username")
-  expect_equal(obj$t("login:username", "fr"), "Username")
+  expect_equal(obj$t("login:username", language = "fr"), "username")
 })

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -141,3 +141,32 @@ test_that("can set default namespace, and reset it later", {
   res$value()
   expect_equal(obj$default_namespace(), "common")
 })
+
+
+test_that("test resource bundles exist", {
+  obj <- i18n(traduire_file("examples/namespaces.json"),
+              default_namespace = "common")
+  expect_true(obj$has_resource_bundle("en", "login"))
+  expect_false(obj$has_resource_bundle("en", "logout"))
+  expect_false(obj$has_resource_bundle("gr", "login"))
+})
+
+
+test_that("load resource bundles", {
+  obj <- i18n(NULL, default_namespace = "common")
+  expect_false(obj$has_resource_bundle("en", "common"))
+  obj$add_resource_bundle("en", "common",
+                          traduire_file("examples/structured/en-common.json"))
+  obj$add_resource_bundle("en", "login",
+                          traduire_file("examples/structured/en-login.json"))
+  obj$add_resource_bundle("fr", "common",
+                          traduire_file("examples/structured/fr-common.json"))
+  expect_true(obj$has_resource_bundle("en", "common"))
+  expect_true(obj$has_resource_bundle("en", "login"))
+  expect_true(obj$has_resource_bundle("fr", "common"))
+  expect_false(obj$has_resource_bundle("fr", "login"))
+  expect_equal(obj$t("hello"), "hello world")
+  expect_equal(obj$t("hello", language = "fr"), "salut le monde")
+  expect_equal(obj$t("login:username"), "Username")
+  expect_equal(obj$t("login:username", "fr"), "Username")
+})

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -17,5 +17,5 @@ test_that("sensible errors on missing files", {
 
 test_that("read_input passes json through", {
   dat <- '{"a" : "b"}'
-  expect_equal(read_input(dat), V8::JS(dat))
+  expect_equal(read_input(dat), jsonlite::unbox(dat))
 })

--- a/vignettes/traduire.Rmd
+++ b/vignettes/traduire.Rmd
@@ -212,7 +212,7 @@ The full package is included as an example within `traduire` at `system.file("he
 
 ```{r, results = "asis", echo = FALSE}
 path_hello <- system.file("hello", package = "traduire", mustWork = TRUE)
-writeLines(tree(system.file("hello", package = "traduire"), "hello"))
+writeLines(tree(path_hello, "hello"))
 ```
 
 Below is the code in `hello.R`, which can say rough translations of "hello world" in a number of languages:
@@ -312,19 +312,44 @@ lang_output("json", readLines(path))
 
 When constructing the translator object we can provide a default namespace (it defaults to `translation`):
 
-```
+```{r}
 tr <- traduire::i18n(path, default_namespace = "common")
 ```
 
 Keys that are provided without an explicit namespace, will be looked up in the default namespace:
 
-```
+```{r}
 tr$t("hello")
 ```
 
 or provide a namespace when looking up keys:
 
-```
+```{r}
 tr$t("common:hello", language = "fr")
 tr$t("login:username", language = "fr")
+```
+
+So far, this brings relatively little advantage as our file, while structured, is still going to end up really large as all the files end up in it.  So we might want to break it up like so:
+
+```{r, results = "asis", echo = FALSE}
+path <- system.file("examples/structured", package = "traduire",
+                    mustWork = TRUE)
+writeLines(tree(path, "structured"))
+```
+
+where each file is orgnanised like:
+
+```{r, results = "asis", echo = FALSE}
+lang_output("json", readLines(file.path(path, "en-login.json")))
+```
+
+to allow this, we need to load the files one by one into the translation object, rather than as a single resource bundle.  To do this, we can use the `add_resource_bundle` method:
+
+```{r}
+obj <- i18n(NULL)
+obj$add_resource_bundle("en", "common", file.path(path, "en-common.json"))
+obj$add_resource_bundle("en", "login", file.path(path, "en-login.json"))
+obj$add_resource_bundle("fr", "common", file.path(path, "fr-common.json"))
+obj$add_resource_bundle("fr", "login", file.path(path, "fr-login.json"))
+obj$t("login:password", language = "fr")
 ```

--- a/vignettes/traduire.Rmd
+++ b/vignettes/traduire.Rmd
@@ -353,3 +353,26 @@ obj$add_resource_bundle("fr", "common", file.path(path, "fr-common.json"))
 obj$add_resource_bundle("fr", "login", file.path(path, "fr-login.json"))
 obj$t("login:password", language = "fr")
 ```
+
+This is clearly going to be error prone to do with a large number of translation files, though a loop could help:
+
+```{r}
+obj <- traduire::i18n(NULL)
+for (language in c("en", "fr")) {
+  for (namespace in c("common", "login")) {
+    bundle <- file.path(path, sprintf("%s-%s.json", language, namespace))
+    obj$add_resource_bundle(language, namespace, bundle)
+  }
+}
+obj$t("login:password", language = "fr")
+```
+
+An alternative is to pass in the pattern used to locate these files, though this approach works best if you also declare your namespaces and languages up front.  The pattern uses glue's syntax, and the pattern must include placeholders `language` and `namespace` (and no others):
+
+```{r}
+pattern <- file.path(path, "{language}-{namespace}.json")
+obj <- traduire::i18n(NULL, resource_pattern = pattern,
+                      languages = c("en", "fr"),
+                      namespaces = c("common", "login"))
+obj$t("login:password", language = "fr")
+```

--- a/vignettes/traduire.Rmd
+++ b/vignettes/traduire.Rmd
@@ -346,7 +346,7 @@ lang_output("json", readLines(file.path(path, "en-login.json")))
 to allow this, we need to load the files one by one into the translation object, rather than as a single resource bundle.  To do this, we can use the `add_resource_bundle` method:
 
 ```{r}
-obj <- i18n(NULL)
+obj <- traduire::i18n(NULL)
 obj$add_resource_bundle("en", "common", file.path(path, "en-common.json"))
 obj$add_resource_bundle("en", "login", file.path(path, "en-login.json"))
 obj$add_resource_bundle("fr", "common", file.path(path, "fr-common.json"))

--- a/vignettes/traduire.Rmd
+++ b/vignettes/traduire.Rmd
@@ -97,7 +97,7 @@ The translation file looks like:
 ```{r, results = "asis", echo = FALSE}
 path_validation <- system.file("examples/validation.json",
                                package = "traduire", mustWork = TRUE)
-lang_output("json", readLines(path))
+lang_output("json", readLines(path_validation))
 ```
 
 where the `_plural` suffix is important for `i18next` for determining the string to return for a singular or plural case, and the `count` element determines if the string is singular or plural.
@@ -126,12 +126,12 @@ tr$t("nocols", list(missing = "A, B"), count = 2, language = "fr")
 
 The motivating use case we had was translating a json file for use in an [upstream web application](http://github.com/mrc-ide/hint), so the text to translate might contain data like:
 
-```
+```json
 {
   "id": "area_scope",
-  "label": "element label",
+  "label": "element_label",
   "type": "multiselect",
-  "description": "element description"
+  "description": "element_description"
 }
 ```
 
@@ -185,6 +185,8 @@ or, into French:
 writeLines(tr$replace(string, language = "fr"))
 ```
 
+Note that while the input text here is json, it could be anything at all, and will not be parsed as json.
+
 ## Use within a package
 
 We provide an optional workflow for using translations within a package, or some other piece of code where the translations will be fairly invasive to add, allowing you to write essentially:
@@ -212,7 +214,7 @@ The full package is included as an example within `traduire` at `system.file("he
 
 ```{r, results = "asis", echo = FALSE}
 path_hello <- system.file("hello", package = "traduire", mustWork = TRUE)
-writeLines(tree(path_hello, "hello"))
+lang_output("plain", tree(path_hello, "hello"))
 ```
 
 Below is the code in `hello.R`, which can say rough translations of "hello world" in a number of languages:
@@ -334,7 +336,7 @@ So far, this brings relatively little advantage as our file, while structured, i
 ```{r, results = "asis", echo = FALSE}
 path <- system.file("examples/structured", package = "traduire",
                     mustWork = TRUE)
-writeLines(tree(path, "structured"))
+lang_output("plain", tree(path, "structured"))
 ```
 
 where each file is orgnanised like:

--- a/vignettes/traduire.Rmd
+++ b/vignettes/traduire.Rmd
@@ -289,3 +289,42 @@ $ curl -H "Accept-Language: ko" http://localhost:8888/hello/cat
       jgs  //_// ___/
                \_)
 ```
+
+## Namespaces, and the structure of translation files
+
+This section outlines how to write the translation (json) files, alongside a discussion of using namespaces.  Consider again the first example:
+
+```{r, results = "asis", echo = FALSE}
+path <- system.file("examples/simple.json", package = "traduire",
+                    mustWork = TRUE)
+lang_output("json", readLines(path))
+```
+
+In this format, the top level keys (`en`, `fr`) represent _languages_ and the next level key (`translation`) which appears redundant represents a [_namespace_](https://www.i18next.com/principles/namespaces).  A translation set can have multiple namespaces, which can help with organising a large set of strings, and can be used to split the file up over smaller files that might be easier to work with (see below).
+
+Below, we have file with two namespaces, `common` and `login`.  These might represent strings used throughout the application and in a login component, for example.
+
+```{r, results = "asis", echo = FALSE}
+path <- system.file("examples/namespaces.json", package = "traduire",
+                    mustWork = TRUE)
+lang_output("json", readLines(path))
+```
+
+When constructing the translator object we can provide a default namespace (it defaults to `translation`):
+
+```
+tr <- traduire::i18n(path, default_namespace = "common")
+```
+
+Keys that are provided without an explicit namespace, will be looked up in the default namespace:
+
+```
+tr$t("hello")
+```
+
+or provide a namespace when looking up keys:
+
+```
+tr$t("common:hello", language = "fr")
+tr$t("login:username", language = "fr")
+```


### PR DESCRIPTION
It might be possible to break this PR into two, but I think it's easiest to motivate as this one PR.

This PR will allow us to structure translations into namespaces and by languages, which will make it much more pleasant to write translations for hintr/naomi.

The motivation is largely covered by the vignette, which has been expanded.  Once a resources set is split by language/namespace it immediately becomes annoying to load and we need to load it somewhat more automatically into the object.  i18next supports "backend plugins" for this (see [the docs](https://www.i18next.com/misc/creating-own-plugins)) - I've sketched out a very basic plugin here, but it will certainly change.

This PR starts making the interface groan quite a lot - we'll need to start refactoring that into a configuration object, but that should ideally wait for a new PR - try to look past it for this one but thoughts welcome.  This PR also starts bringing us closer to needing to properly support the fallback interface and logging, both of which I've avoided touching here.

The awkward bit of the PR is the R -> JS -> R callback, but that's ended up not too bad here I think.