### PR TITLE
reside-78: allow listing of registered translators

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: traduire
 Title: Example Translation in a Package
-Version: 0.0.1
+Version: 0.0.2
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(i18n)
 export(t_)
 export(translator)
+export(translator_list)
 export(translator_register)
 export(translator_set_language)
 export(translator_translate)

--- a/R/translator.R
+++ b/R/translator.R
@@ -42,7 +42,13 @@
 ##'   break.  This may get tightened up at some point (RESIDE-79).
 ##'
 ##' @title Register a translator
-##' @inheritParams i18n
+##'
+##' @param ... For \code{translator_register}, arguments passed to
+##'   \code{\link{i18n}} to build the translator object.  All
+##'   arguments are accepted.  For \code{translator_translate} and
+##'   \code{t_}, arguments passed to the \code{$t} method of the
+##'   translator object, being \code{string}, \code{data},
+##'   \code{language} etc.
 ##'
 ##' @param name Optional name for the translator.  If omitted, this
 ##'   will be determined automatically if called from package code
@@ -55,9 +61,9 @@
 ##' traduire::t_("hello", language = "fr", name = "myexample")
 ##' "myexample" %in% traduire::translator_list()
 ##' traduire::translator_unregister("myexample")
-translator_register <- function(resources, language = NULL, name = NULL) {
+translator_register <- function(..., name = NULL) {
   name <- name_from_context(name)
-  translators[[name]] <- i18n(resources, language)
+  translators[[name]] <- i18n(...)
 }
 
 
@@ -69,10 +75,6 @@ translator_unregister <- function(name = NULL) {
 }
 
 
-##' @param ... Arguments passed to \code{\link{i18n}}'s \code{t}
-##'   method, being \code{string}, \code{data}, \code{language} etc.
-##'
-##' @inheritParams translator_register
 ##' @export
 ##' @rdname translator
 translator_translate <- function(..., name = NULL) {

--- a/R/translator.R
+++ b/R/translator.R
@@ -35,6 +35,12 @@
 ##'   your package code, then the correct translator should be found
 ##'   automatically.
 ##'
+##' @section Warning:
+##'
+##' Do not use \code{translator_unregister} on someone elses's
+##'   translator, particularly not in package code, or things will
+##'   break.  This may get tightened up at some point (RESIDE-79).
+##'
 ##' @title Register a translator
 ##' @inheritParams i18n
 ##'
@@ -47,6 +53,7 @@
 ##' path <- system.file("examples/simple.json", package = "traduire")
 ##' traduire::translator_register(path, name = "myexample")
 ##' traduire::t_("hello", language = "fr", name = "myexample")
+##' "myexample" %in% traduire::translator_list()
 ##' traduire::translator_unregister("myexample")
 translator_register <- function(resources, language = NULL, name = NULL) {
   name <- name_from_context(name)
@@ -97,6 +104,13 @@ translator <- function(name = NULL) {
 ##' @rdname translator
 translator_set_language <- function(language, name = NULL) {
   translator(name)$set_language(language)
+}
+
+
+##' @rdname translator
+##' @export
+translator_list <- function() {
+  names(translators)
 }
 
 

--- a/man/translator.Rd
+++ b/man/translator.Rd
@@ -7,6 +7,7 @@
 \alias{t_}
 \alias{translator}
 \alias{translator_set_language}
+\alias{translator_list}
 \title{Register a translator}
 \usage{
 translator_register(resources, language = NULL, name = NULL)
@@ -20,6 +21,8 @@ t_(..., name = NULL)
 translator(name = NULL)
 
 translator_set_language(language, name = NULL)
+
+translator_list()
 }
 \arguments{
 \item{resources}{Path to a json file containing translation
@@ -76,9 +79,18 @@ Every package's translator object is isolated from every other
   automatically.
 }
 
+\section{Warning}{
+
+
+Do not use \code{translator_unregister} on someone elses's
+  translator, particularly not in package code, or things will
+  break.  This may get tightened up at some point (RESIDE-79).
+}
+
 \examples{
 path <- system.file("examples/simple.json", package = "traduire")
 traduire::translator_register(path, name = "myexample")
 traduire::t_("hello", language = "fr", name = "myexample")
+"myexample" \%in\% traduire::translator_list()
 traduire::translator_unregister("myexample")
 }

--- a/man/translator.Rd
+++ b/man/translator.Rd
@@ -10,7 +10,7 @@
 \alias{translator_list}
 \title{Register a translator}
 \usage{
-translator_register(resources, language = NULL, name = NULL)
+translator_register(..., name = NULL)
 
 translator_unregister(name = NULL)
 
@@ -25,19 +25,18 @@ translator_set_language(language, name = NULL)
 translator_list()
 }
 \arguments{
-\item{resources}{Path to a json file containing translation
-resources. If given in this way, then on-demand translation
-loading (via \code{resource_pattern}) is disabled unless a
-currently unexposed i18next option is used.}
-
-\item{language}{Language to use, passed through to
-\code{\link{i18n}}'s \code{set_language} method}
+\item{...}{For \code{translator_register}, arguments passed to
+\code{\link{i18n}} to build the translator object.  All
+arguments are accepted.  For \code{translator_translate} and
+\code{t_}, arguments passed to the \code{$t} method of the
+translator object, being \code{string}, \code{data},
+\code{language} etc.}
 
 \item{name}{Optional name for the translator.  If omitted, this
 will be determined automatically if called from package code}
 
-\item{...}{Arguments passed to \code{\link{i18n}}'s \code{t}
-method, being \code{string}, \code{data}, \code{language} etc.}
+\item{language}{Language to use, passed through to
+\code{\link{i18n}}'s \code{set_language} method}
 }
 \description{
 Register a translator within the \code{traduire} package, and use

--- a/tests/testthat/test-translator.R
+++ b/tests/testthat/test-translator.R
@@ -6,6 +6,7 @@ test_that("translator register, use, unregister", {
   res <- withVisible(translator_register(path, name = name))
   expect_false(res$visible)
   expect_is(res$value, "i18n")
+  expect_true(name %in% translator_list())
 
   expect_identical(translator(name), res$value)
   expect_equal(translator_translate("hello", language = "fr", name = name),
@@ -15,6 +16,7 @@ test_that("translator register, use, unregister", {
   expect_true(exists(name, translators))
   translator_unregister(name)
   expect_false(exists(name, translators))
+  expect_false(name %in% translator_list())
 })
 
 


### PR DESCRIPTION
This PR implements a couple of small features needed for getting things working with hintr:

- list registered translators (so we can test that things are set up correctly)
- pass all arguments along when building the translation objects (really needed for #6 because the arg list gets more complicated)