### PR TITLE
reside-79: Prevent antisocial unregistering of translators

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: traduire
 Title: Example Translation in a Package
-Version: 0.0.2
+Version: 0.0.3
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/R/translator.R
+++ b/R/translator.R
@@ -64,8 +64,12 @@
 ##'   translator object, being \code{string}, \code{data},
 ##'   \code{language} etc.
 ##'
-##' @param name Optional name for the translator.  If omitted, this
-##'   will be determined automatically if called from package code
+##' @param name Optional name for the translator.  This should be used
+##'   only when not using this interface from a package (e.g., from a
+##'   shiny application).  If using from a package you can omit both
+##'   \code{name} and \code{package}, and if interacting with
+##'   translations from another package you should use the
+##'   \code{package} argument (see below).
 ##'
 ##' @param package Optional name for the package to find a translator
 ##'   in.  This cannot be provided for \code{translator_register} and

--- a/R/translator.R
+++ b/R/translator.R
@@ -140,6 +140,15 @@ translator_list <- function() {
 }
 
 
+## name will be provided only for non-package use (hence the
+## check/stop below)
+##
+## if used from a package, then package should be empty - that
+## argument should be used when refering to other packages.
+##
+## In order to prevent registration/unregistration of translators from
+## other packages, if  package *is* provided and strict  is TRUE, then
+## we verify that the correct name was given.
 name_from_context <- function(name = NULL, package = NULL, strict = FALSE) {
   prefix <- "package:"
   if (!is.null(package)) {

--- a/R/translator.R
+++ b/R/translator.R
@@ -35,11 +35,25 @@
 ##'   your package code, then the correct translator should be found
 ##'   automatically.
 ##'
-##' @section Warning:
+##' If you need to get a translation for another package, you should
+##'   use \code{package} argument, for example:
 ##'
-##' Do not use \code{translator_unregister} on someone elses's
-##'   translator, particularly not in package code, or things will
-##'   break.  This may get tightened up at some point (RESIDE-79).
+##' \preformatted{
+##' traduire::t_("key", package = "other")
+##' }
+##'
+##' You can change the language in another package (e.g., using
+##'   \code{traduire::change_language("en", package = "other")}) but
+##'   should be careful to reset this using the returned reset
+##'   function.
+##'
+##' It is not possible to unregister a translator in another package,
+##'   or to overwrite one.
+##'
+##' Translators provided in other packages will be listed by
+##'   \code{traduire::translator_list} with the prefix \code{package:}
+##'   (e.g., \code{package:other}) however, you should not access them
+##'   directly using \code{name = "package:other"}.
 ##'
 ##' @title Register a translator
 ##'

--- a/R/util.R
+++ b/R/util.R
@@ -49,3 +49,8 @@ safe_js_null <- function(x) {
   }
   x
 }
+
+
+starts_with <- function(string, prefix) {
+  substr(string, 1, nchar(prefix)) == prefix
+}

--- a/man/translator.Rd
+++ b/man/translator.Rd
@@ -32,8 +32,12 @@ arguments are accepted.  For \code{translator_translate} and
 translator object, being \code{string}, \code{data},
 \code{language} etc.}
 
-\item{name}{Optional name for the translator.  If omitted, this
-will be determined automatically if called from package code}
+\item{name}{Optional name for the translator.  This should be used
+only when not using this interface from a package (e.g., from a
+shiny application).  If using from a package you can omit both
+\code{name} and \code{package}, and if interacting with
+translations from another package you should use the
+\code{package} argument (see below).}
 
 \item{package}{Optional name for the package to find a translator
 in.  This cannot be provided for \code{translator_register} and

--- a/man/translator.Rd
+++ b/man/translator.Rd
@@ -82,14 +82,26 @@ Every package's translator object is isolated from every other
   package, and if the \code{traduire} functions are called from
   your package code, then the correct translator should be found
   automatically.
+
+If you need to get a translation for another package, you should
+  use \code{package} argument, for example:
+
+\preformatted{
+traduire::t_("key", package = "other")
 }
 
-\section{Warning}{
+You can change the language in another package (e.g., using
+  \code{traduire::change_language("en", package = "other")}) but
+  should be careful to reset this using the returned reset
+  function.
 
+It is not possible to unregister a translator in another package,
+  or to overwrite one.
 
-Do not use \code{translator_unregister} on someone elses's
-  translator, particularly not in package code, or things will
-  break.  This may get tightened up at some point (RESIDE-79).
+Translators provided in other packages will be listed by
+  \code{traduire::translator_list} with the prefix \code{package:}
+  (e.g., \code{package:other}) however, you should not access them
+  directly using \code{name = "package:other"}.
 }
 
 \examples{

--- a/man/translator.Rd
+++ b/man/translator.Rd
@@ -14,13 +14,13 @@ translator_register(..., name = NULL)
 
 translator_unregister(name = NULL)
 
-translator_translate(..., name = NULL)
+translator_translate(..., name = NULL, package = NULL)
 
-t_(..., name = NULL)
+t_(..., name = NULL, package = NULL)
 
-translator(name = NULL)
+translator(name = NULL, package = NULL)
 
-translator_set_language(language, name = NULL)
+translator_set_language(language, name = NULL, package = NULL)
 
 translator_list()
 }
@@ -34,6 +34,12 @@ translator object, being \code{string}, \code{data},
 
 \item{name}{Optional name for the translator.  If omitted, this
 will be determined automatically if called from package code}
+
+\item{package}{Optional name for the package to find a translator
+in.  This cannot be provided for \code{translator_register} and
+\code{translator_unregister} as these should either be
+registered by \code{name} or the package will be determined
+automatically.}
 
 \item{language}{Language to use, passed through to
 \code{\link{i18n}}'s \code{set_language} method}


### PR DESCRIPTION
This PR primarily prevents unregistering and overwriting of translators in one package by those of another.  It tightens up use of translators within a package so that if not using the implicit package detection (which is what we need to do when dealing with naomi's language from hintr) we use the argument `package = "other"` and not `name = "package:other"`, which stops us depending on an implementation detail