### PR TITLE
reside-85: Support for language fallback

### DIFF
--- a/R/i18n.R
+++ b/R/i18n.R
@@ -43,7 +43,7 @@
 ##'
 ##' @param fallback The fallback language to use.  The options here
 ##'   are to use a character string (a single fallback to use for all
-##'   languages), a character vecto (a series of languages to use in
+##'   languages), a character vector (a series of languages to use in
 ##'   turn, listed from first to try to last to try) or a named list
 ##'   of language-fallback mappings, e.g., \code{list("de-CH": c("fr",
 ##'   "it"), "es": "fr")}.

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -41,6 +41,8 @@
 ##'   method.  Note that the adding a language here does not (yet)
 ##'   mean that failure to load the language is an error.
 ##'
+##' @param fallback The fallback language to use
+##'
 ##' @export
 ##' @examples
 ##' path <- system.file("examples/simple.json", package = "traduire")
@@ -48,11 +50,12 @@
 ##' obj$t("hello", language = "fr")
 i18n <- function(resources, language = NULL, default_namespace = NULL,
                  debug = FALSE, resource_pattern = NULL,
-                 namespaces = NULL, languages = NULL) {
+                 namespaces = NULL, languages = NULL,
+                 fallback = NULL) {
   ## TODO: better defaults for language, but there's lots to consider
   ## with fallbacks still
   R6_i18n$new(resources, language %||% "en", default_namespace,
-              debug, resource_pattern, namespaces, languages)
+              debug, resource_pattern, namespaces, languages, fallback)
 }
 
 
@@ -66,7 +69,8 @@ R6_i18n <- R6::R6Class(
 
   public = list(
     initialize = function(resources, language, default_namespace,
-                          debug, resource_pattern, namespaces, languages) {
+                          debug, resource_pattern, namespaces, languages,
+                          fallback) {
       resources_js <- read_input(resources)
       private$context <- V8::v8()
       private$context$source(traduire_file("js/bundle.js"))
@@ -75,7 +79,8 @@ R6_i18n <- R6::R6Class(
                            debug,
                            safe_js_null(resource_pattern),
                            namespaces %||% "translation",
-                           safe_js_null(languages))
+                           safe_js_null(languages),
+                           safe_js_null(fallback))
     },
 
     t = function(string, data = NULL, language = NULL, count = NULL,

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -51,7 +51,7 @@
 i18n <- function(resources, language = NULL, default_namespace = NULL,
                  debug = FALSE, resource_pattern = NULL,
                  namespaces = NULL, languages = NULL,
-                 fallback = NULL) {
+                 fallback = "dev") {
   ## TODO: better defaults for language, but there's lots to consider
   ## with fallbacks still
   R6_i18n$new(resources, language %||% "en", default_namespace,
@@ -74,13 +74,14 @@ R6_i18n <- R6::R6Class(
       resources_js <- read_input(resources)
       private$context <- V8::v8()
       private$context$source(traduire_file("js/bundle.js"))
-      private$context$call("init", resources_js, language,
+      private$context$call("init", resources_js, scalar(language),
                            safe_js_null(default_namespace),
-                           debug,
+                           scalar(debug),
                            safe_js_null(resource_pattern),
                            namespaces %||% "translation",
                            safe_js_null(languages),
-                           safe_js_null(fallback))
+                           safe_js_null(fallback),
+                           auto_unbox = FALSE)
     },
 
     t = function(string, data = NULL, language = NULL, count = NULL,

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -41,7 +41,12 @@
 ##'   method.  Note that the adding a language here does not (yet)
 ##'   mean that failure to load the language is an error.
 ##'
-##' @param fallback The fallback language to use
+##' @param fallback The fallback language to use.  The options here
+##'   are to use a character string (a single fallback to use for all
+##'   languages), a character vecto (a series of languages to use in
+##'   turn, listed from first to try to last to try) or a named list
+##'   of language-fallback mappings, e.g., \code{list("de-CH": c("fr",
+##'   "it"), "es": "fr")}.
 ##'
 ##' @export
 ##' @examples

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -190,6 +190,9 @@ i18n_replace1 <- function(text, t) {
 ## The debug level here should be tuneable, and that will be easiest
 ## to do once the logging backend is done.
 i18n_backend_read <- function(pattern, language, namespace) {
+  if (is_missing(pattern)) {
+    return(jsonlite::unbox("null"))
+  }
   data <- list(language = language, namespace = namespace)
   path <- glue::glue(pattern, .envir = data)
   tryCatch(

--- a/R/util.R
+++ b/R/util.R
@@ -59,3 +59,18 @@ is_missing <- function(x) {
 scalar <- function(x) {
   jsonlite::unbox(x)
 }
+
+
+squote <- function(x) {
+  sprintf("'%s'", x)
+}
+
+
+is_named <- function(x) {
+  !is.null(names(x))
+}
+
+
+vlapply <- function(X, FUN, ...) {
+  vapply(X, FUN, logical(1), ...)
+}

--- a/R/util.R
+++ b/R/util.R
@@ -54,3 +54,8 @@ safe_js_null <- function(x) {
 is_missing <- function(x) {
   is.null(x) || (length(x) == 1L && is.na(x))
 }
+
+
+scalar <- function(x) {
+  jsonlite::unbox(x)
+}

--- a/R/util.R
+++ b/R/util.R
@@ -49,3 +49,8 @@ safe_js_null <- function(x) {
   }
   x
 }
+
+
+is_missing <- function(x) {
+  is.null(x) || (length(x) == 1L && is.na(x))
+}

--- a/inst/js/bundle.js
+++ b/inst/js/bundle.js
@@ -13,7 +13,7 @@ global.Promise = require("promise");
 global.i18next = require("i18next");
 
 global.init = function(resources, lng, defaultNS, debug, resourcePattern,
-                       namespaces, languages) {
+                       namespaces, languages, fallback) {
     var options = {
         "lng": lng,
         // it's important that 'resources' comes through as null, not
@@ -26,6 +26,7 @@ global.init = function(resources, lng, defaultNS, debug, resourcePattern,
         "initImmediate": true,
         "ns": namespaces,
         "preload": languages,
+        "fallbackLng": fallback,
         "backend": {
             "resourcePattern": resourcePattern
         }

--- a/js/in.js
+++ b/js/in.js
@@ -11,7 +11,7 @@ global.Promise = require("promise");
 global.i18next = require("i18next");
 
 global.init = function(resources, lng, defaultNS, debug, resourcePattern,
-                       namespaces, languages) {
+                       namespaces, languages, fallback) {
     var options = {
         "lng": lng,
         // it's important that 'resources' comes through as null, not
@@ -24,6 +24,7 @@ global.init = function(resources, lng, defaultNS, debug, resourcePattern,
         "initImmediate": true,
         "ns": namespaces,
         "preload": languages,
+        "fallbackLng": fallback,
         "backend": {
             "resourcePattern": resourcePattern
         }

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -11,7 +11,8 @@ i18n(
   debug = FALSE,
   resource_pattern = NULL,
   namespaces = NULL,
-  languages = NULL
+  languages = NULL,
+  fallback = NULL
 )
 }
 \arguments{
@@ -47,6 +48,8 @@ probably do better with the logic here.}
 always add additional languages using the \code{load_language}
 method.  Note that the adding a language here does not (yet)
 mean that failure to load the language is an error.}
+
+\item{fallback}{The fallback language to use}
 }
 \description{
 Create a new translator object

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -49,7 +49,12 @@ always add additional languages using the \code{load_language}
 method.  Note that the adding a language here does not (yet)
 mean that failure to load the language is an error.}
 
-\item{fallback}{The fallback language to use}
+\item{fallback}{The fallback language to use.  The options here
+are to use a character string (a single fallback to use for all
+languages), a character vecto (a series of languages to use in
+turn, listed from first to try to last to try) or a named list
+of language-fallback mappings, e.g., \code{list("de-CH": c("fr",
+"it"), "es": "fr")}.}
 }
 \description{
 Create a new translator object

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -12,7 +12,7 @@ i18n(
   resource_pattern = NULL,
   namespaces = NULL,
   languages = NULL,
-  fallback = NULL
+  fallback = "dev"
 )
 }
 \arguments{

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -51,7 +51,7 @@ mean that failure to load the language is an error.}
 
 \item{fallback}{The fallback language to use.  The options here
 are to use a character string (a single fallback to use for all
-languages), a character vecto (a series of languages to use in
+languages), a character vector (a series of languages to use in
 turn, listed from first to try to last to try) or a named list
 of language-fallback mappings, e.g., \code{list("de-CH": c("fr",
 "it"), "es": "fr")}.}

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -176,7 +176,6 @@ test_that("load resource bundles", {
 
 test_that("simple fallback", {
   obj <- i18n(NULL, default_namespace = "common", fallback = "en")
-  expect_false(obj$has_resource_bundle("en", "common"))
   obj$add_resource_bundle("en", "common",
                           traduire_file("examples/structured/en-common.json"))
   obj$add_resource_bundle("en", "login",
@@ -191,7 +190,6 @@ test_that("simple fallback", {
 
 test_that("vector fallback", {
   obj <- i18n(NULL, default_namespace = "common", fallback = c("fr", "en"))
-  expect_false(obj$has_resource_bundle("en", "common"))
   obj$add_resource_bundle("en", "common",
                           traduire_file("examples/structured/en-common.json"))
   obj$add_resource_bundle("en", "login",
@@ -202,8 +200,26 @@ test_that("vector fallback", {
   expect_equal(obj$t("hello", language = "en"), "hello world")
   expect_equal(obj$t("hello", language = "fr"), "salut le monde")
   expect_equal(obj$t("hello", language = "ko"), "salut le monde")
+  expect_equal(obj$t("hello", language = "cimode"), "hello")
 
   expect_equal(obj$t("login:username", language = "en"), "Username")
   expect_equal(obj$t("login:username", language = "fr"), "Username")
   expect_equal(obj$t("login:username", language = "ko"), "Username")
+  expect_equal(obj$t("login:username", language = "cimode"), "username")
+})
+
+
+## This one is pretty contrived but it works:
+test_that("structured fallback", {
+  fallback <- list(en = "fr", fr = "en")
+  obj <- i18n(NULL, default_namespace = "common", fallback = fallback)
+  obj$add_resource_bundle("en", "login",
+                          traduire_file("examples/structured/en-login.json"))
+  obj$add_resource_bundle("fr", "common",
+                          traduire_file("examples/structured/fr-common.json"))
+
+  expect_equal(obj$t("hello", language = "en"), "salut le monde")
+  expect_equal(obj$t("login:username", language = "en"), "Username")
+  expect_equal(obj$t("hello", language = "fr"), "salut le monde")
+  expect_equal(obj$t("login:username", language = "fr"), "Username")
 })

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -172,3 +172,38 @@ test_that("load resource bundles", {
   expect_equal(obj$t("login:username"), "Username")
   expect_equal(obj$t("login:username", language = "fr"), "username")
 })
+
+
+test_that("simple fallback", {
+  obj <- i18n(NULL, default_namespace = "common", fallback = "en")
+  expect_false(obj$has_resource_bundle("en", "common"))
+  obj$add_resource_bundle("en", "common",
+                          traduire_file("examples/structured/en-common.json"))
+  obj$add_resource_bundle("en", "login",
+                          traduire_file("examples/structured/en-login.json"))
+  obj$add_resource_bundle("fr", "common",
+                          traduire_file("examples/structured/fr-common.json"))
+  expect_equal(obj$t("hello", language = "en"), "hello world")
+  expect_equal(obj$t("hello", language = "fr"), "salut le monde")
+  expect_equal(obj$t("hello", language = "ko"), "hello world")
+})
+
+
+test_that("vector fallback", {
+  obj <- i18n(NULL, default_namespace = "common", fallback = c("fr", "en"))
+  expect_false(obj$has_resource_bundle("en", "common"))
+  obj$add_resource_bundle("en", "common",
+                          traduire_file("examples/structured/en-common.json"))
+  obj$add_resource_bundle("en", "login",
+                          traduire_file("examples/structured/en-login.json"))
+  obj$add_resource_bundle("fr", "common",
+                          traduire_file("examples/structured/fr-common.json"))
+
+  expect_equal(obj$t("hello", language = "en"), "hello world")
+  expect_equal(obj$t("hello", language = "fr"), "salut le monde")
+  expect_equal(obj$t("hello", language = "ko"), "salut le monde")
+
+  expect_equal(obj$t("login:username", language = "en"), "Username")
+  expect_equal(obj$t("login:username", language = "fr"), "Username")
+  expect_equal(obj$t("login:username", language = "ko"), "Username")
+})

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -185,6 +185,8 @@ test_that("simple fallback", {
   expect_equal(obj$t("hello", language = "en"), "hello world")
   expect_equal(obj$t("hello", language = "fr"), "salut le monde")
   expect_equal(obj$t("hello", language = "ko"), "hello world")
+  ## Keep falling and we get the key
+  expect_equal(obj$t("missing"), "missing")
 })
 
 

--- a/tests/testthat/test-validate.R
+++ b/tests/testthat/test-validate.R
@@ -1,0 +1,50 @@
+context("validate")
+
+
+test_that("validate_fallback: happy path", {
+  expect_equal(validate_fallback(NULL), V8::JS("null"))
+  expect_equal(validate_fallback("a"), "a")
+  expect_equal(validate_fallback(c("a", "b")), c("a", "b"))
+  expect_equal(validate_fallback(c(x = "a", y = "b")), list(x = "a", y = "b"))
+  expect_equal(validate_fallback(list(x = "a", y = "b")),
+               list(x = "a", y = "b"))
+  expect_equal(validate_fallback(list(x = c("a", "b"), y = "b")),
+               list(x = c("a", "b"), y = "b"))
+})
+
+
+test_that("validate_fallback: error cases", {
+  expect_error(
+    validate_fallback(1),
+    "fallback must be a character vector or list of character vectors")
+
+  expect_error(
+    validate_fallback(c("a", NA)),
+    "All fallback entries must be non-NA and non-empty")
+  expect_error(
+    validate_fallback(c("a", "")),
+    "All fallback entries must be non-NA and non-empty")
+  expect_error(
+    validate_fallback(c(NA, "")),
+    "All fallback entries must be non-NA and non-empty")
+
+  expect_error(
+    validate_fallback(list("a", "b")),
+    "If fallback is a list, it must be named")
+
+  expect_error(
+    validate_fallback(list(x = "a", x = "b")),
+    "Duplicated names in fallback")
+  expect_error(
+    validate_fallback(list(x = "a", "b")),
+    "Zero-length names in fallback")
+
+  expect_error(
+    validate_fallback(list(x = 1, y = 2, z = "en")),
+    "All elements of fallback must be character (see 'x', 'y')", fixed = TRUE)
+
+  expect_error(
+    validate_fallback(list(x = "", y = NA_character_, z = "en")),
+    "All elements of fallback must be non-NA and non-empty (see 'x', 'y')",
+    fixed = TRUE)
+})

--- a/vignettes/traduire.Rmd
+++ b/vignettes/traduire.Rmd
@@ -122,6 +122,36 @@ tr$t("nocols", list(missing = "A"), count = 1, language = "fr")
 tr$t("nocols", list(missing = "A, B"), count = 2, language = "fr")
 ```
 
+## Fallback language
+
+To illustrate this feature, we use a list of translations of `Hello world!` which includes many languages.
+
+```{r}
+path_hello <- system.file("hello/inst/traduire.json", package = "traduire")
+```
+
+Most simply, if we want to fall back onto a single language for all translations, we can provide a fallback language as a string:
+
+```{r}
+tr <- traduire::i18n(path_hello, fallback = "it")
+tr$t("hello", language = "unknown")
+```
+
+Alternatively, a chain of languages to try can be provided:
+
+```{r}
+tr <- traduire::i18n(path_hello, fallback = c("a", "b", "de"))
+tr$t("hello", language = "unknown")
+```
+
+If you want to have different fallback languages for different target languages, provide a named list of mappings (each of which can be a scalar or vector of fallback languages as above):
+
+```{r}
+tr <- traduire::i18n(path_hello, fallback = list(co = "fr", "default" = "en"))
+tr$t("hello", language = "co")
+tr$t("hello", language = "unknown")
+```
+
 ## Translating multiple keys in a block of text
 
 The motivating use case we had was translating a json file for use in an [upstream web application](http://github.com/mrc-ide/hint), so the text to translate might contain data like:


### PR DESCRIPTION
Implement fallbacks, so that if a string is not found in one language, something sensible in another is returned.  This will prevent keys from being displayed to the user.

This is required for mrc-1150, in turn required for mrc-787