### PR TITLE
reside-87: Add support for controlling escaping

### DIFF
--- a/R/i18n.R
+++ b/R/i18n.R
@@ -111,7 +111,7 @@ R6_i18n <- R6::R6Class(
 
     exists = function(string, data = NULL, language = NULL, count = NULL,
                       context = NULL) {
-      options <- i18n_options(data, language, count, context)
+      options <- i18n_options(data, language, count, context, FALSE)
       private$context$call("exists", string, options)
     },
 

--- a/inst/js/bundle.js
+++ b/inst/js/bundle.js
@@ -13,7 +13,8 @@ global.Promise = require("promise");
 global.i18next = require("i18next");
 
 global.init = function(resources, lng, defaultNS, debug, resourcePattern,
-                       namespaces, languages, fallback) {
+                       namespaces, languages, fallback,
+                       interpolationEscapeValue) {
     var options = {
         "lng": lng,
         // it's important that 'resources' comes through as null, not
@@ -27,6 +28,9 @@ global.init = function(resources, lng, defaultNS, debug, resourcePattern,
         "ns": namespaces,
         "preload": languages,
         "fallbackLng": fallback,
+        "interpolation": {
+            "escapeValue": interpolationEscapeValue
+        },
         "backend": {
             "resourcePattern": resourcePattern
         }

--- a/js/in.js
+++ b/js/in.js
@@ -11,7 +11,8 @@ global.Promise = require("promise");
 global.i18next = require("i18next");
 
 global.init = function(resources, lng, defaultNS, debug, resourcePattern,
-                       namespaces, languages, fallback) {
+                       namespaces, languages, fallback,
+                       interpolationEscapeValue) {
     var options = {
         "lng": lng,
         // it's important that 'resources' comes through as null, not
@@ -25,6 +26,9 @@ global.init = function(resources, lng, defaultNS, debug, resourcePattern,
         "ns": namespaces,
         "preload": languages,
         "fallbackLng": fallback,
+        "interpolation": {
+            "escapeValue": interpolationEscapeValue
+        },
         "backend": {
             "resourcePattern": resourcePattern
         }

--- a/man/i18n.Rd
+++ b/man/i18n.Rd
@@ -12,7 +12,8 @@ i18n(
   resource_pattern = NULL,
   namespaces = NULL,
   languages = NULL,
-  fallback = "dev"
+  fallback = "dev",
+  escape = FALSE
 )
 }
 \arguments{
@@ -55,6 +56,11 @@ languages), a character vector (a series of languages to use in
 turn, listed from first to try to last to try) or a named list
 of language-fallback mappings, e.g., \code{list("de-CH": c("fr",
 "it"), "es": "fr")}.}
+
+\item{escape}{Logical, indicating if the translation output should
+be, by default, escaped (see the i18next interpolation
+documentation).  The i18next implementation is to prevent xss
+attacks, and so is disabled by default in traduire.}
 }
 \description{
 Create a new translator object

--- a/tests/testthat/test-i18n.R
+++ b/tests/testthat/test-i18n.R
@@ -225,3 +225,37 @@ test_that("structured fallback", {
   expect_equal(obj$t("hello", language = "fr"), "salut le monde")
   expect_equal(obj$t("login:username", language = "fr"), "Username")
 })
+
+
+test_that("escape interpolation", {
+  input_escaped <- "escaped/here"
+  input_unescaped <- "not/escaped/here"
+  value_escaped <- "i18next is escaped&#x2F;here"
+  value_unescaped <- "i18next is not/escaped/here"
+
+  obj <- i18n(traduire_file("examples/simple.json"), escape = FALSE)
+  expect_equal(
+    obj$t("interpolate", list(what = "i18next", how = input_unescaped)),
+    value_unescaped)
+  expect_equal(
+    obj$t("interpolate", list(what = "i18next", how = input_unescaped),
+          escape = FALSE),
+    value_unescaped)
+  expect_equal(
+    obj$t("interpolate", list(what = "i18next", how = input_escaped),
+          language = "en", escape = TRUE),
+    value_escaped)
+
+  obj <- i18n(traduire_file("examples/simple.json"), escape = TRUE)
+  expect_equal(
+    obj$t("interpolate", list(what = "i18next", how = input_escaped)),
+    value_escaped)
+  expect_equal(
+    obj$t("interpolate", list(what = "i18next", how = input_unescaped),
+          escape = FALSE),
+    value_unescaped)
+  expect_equal(
+    obj$t("interpolate", list(what = "i18next", how = input_escaped),
+          language = "en", escape = TRUE),
+    value_escaped)
+})


### PR DESCRIPTION
This PR exposes control for escaping interpolation.  This is rarely what is wanted from R as we're not trying to build up html.