### PR TITLE
reside-88: Fix bug in fetching of translator by name

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: traduire
 Title: Example Translation in a Package
-Version: 0.0.3
+Version: 0.0.4
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/R/translator.R
+++ b/R/translator.R
@@ -114,7 +114,7 @@ t_ <- translator_translate
 ##' @export
 ##' @rdname translator
 translator <- function(name = NULL, package = NULL) {
-  name <- name_from_context(name)
+  name <- name_from_context(name, package)
   translator <- translators[[name]]
   if (is.null(translator)) {
     stop(sprintf("Did not find translator '%s'", name))

--- a/R/translator.R
+++ b/R/translator.R
@@ -114,7 +114,7 @@ t_ <- translator_translate
 ##' @export
 ##' @rdname translator
 translator <- function(name = NULL, package = NULL) {
-  name <- name_from_context(name, package)
+  name <- name_from_context(name, package, FALSE)
   translator <- translators[[name]]
   if (is.null(translator)) {
     stop(sprintf("Did not find translator '%s'", name))
@@ -149,7 +149,7 @@ translator_list <- function() {
 ## In order to prevent registration/unregistration of translators from
 ## other packages, if  package *is* provided and strict  is TRUE, then
 ## we verify that the correct name was given.
-name_from_context <- function(name = NULL, package = NULL, strict = FALSE) {
+name_from_context <- function(name, package, strict) {
   prefix <- "package:"
   if (!is.null(package)) {
     validate_package_name(package, strict)

--- a/tests/testthat/test-translator.R
+++ b/tests/testthat/test-translator.R
@@ -88,3 +88,14 @@ test_that("name_from_context finds name in package", {
   expect_equal(name_from_context(NULL, NULL, FALSE), "package:pkg")
   expect_equal(name_from_context(NULL, "pkg", FALSE), "package:pkg")
 })
+
+
+test_that("translator get package", {
+  id <- "package:impossible_package"
+  path <- traduire_file("examples/simple.json")
+  translators[[id]] <- i18n(path)
+  on.exit(rm(list = id, translators))
+
+  res <- translator(package = "impossible_package")
+  expect_identical(res, translators[[id]])
+})

--- a/tests/testthat/test-translator.R
+++ b/tests/testthat/test-translator.R
@@ -94,7 +94,7 @@ test_that("translator get package", {
   id <- "package:impossible_package"
   path <- traduire_file("examples/simple.json")
   translators[[id]] <- i18n(path)
-  on.exit(rm(list = id, translators))
+  on.exit(rm(list = id, envir = translators))
 
   res <- translator(package = "impossible_package")
   expect_identical(res, translators[[id]])

--- a/tests/testthat/test-translator.R
+++ b/tests/testthat/test-translator.R
@@ -73,7 +73,7 @@ test_that("validate_package_name requires correct package in strict mode", {
 
 
 test_that("name_from_context rejects a package: prefix", {
-  expect_error(name_from_context(name = "package:whatever"),
+  expect_error(name_from_context("package:whatever", NULL, FALSE),
                "Do not use 'package:' prefix directly")
 })
 


### PR DESCRIPTION
This is now tested slightly better and I've removed the defaults which caused the problem in the first place.