### PR TITLE
Add test and fix for not passing package to translator on call to t_

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,5 @@
 ^docs$
 ^js$
 \.V8history$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ inst/doc
 vignettes/*.html
 vignettes/*.R
 .V8history
+.Rproj.user

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,6 +20,7 @@ Imports:
     R6,
     glue
 Suggests:
+    hello,
     jsonlite,
     knitr,
     mockery,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,6 @@ Imports:
     R6,
     glue
 Suggests:
-    hello,
     jsonlite,
     knitr,
     mockery,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: traduire
 Title: Example Translation in a Package
-Version: 0.0.4
+Version: 0.0.5
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/R/translator.R
+++ b/R/translator.R
@@ -102,7 +102,7 @@ translator_unregister <- function(name = NULL) {
 ##' @export
 ##' @rdname translator
 translator_translate <- function(..., name = NULL, package = NULL) {
-  translator(name)$t(...)
+  translator(name, package)$t(...)
 }
 
 

--- a/tests/testthat/test-translator.R
+++ b/tests/testthat/test-translator.R
@@ -101,9 +101,15 @@ test_that("translator get package", {
 })
 
 test_that("translate from another package", {
-  ## Force .onload from hello to be called to reigster translators
-  hello::hello("test")
-  expect_equal(
-    translator_translate("hello", language = "fr", package = "hello"),
-    "Bonjour le Monde!")
+  mock_translator <- mockery::mock(list(
+    t = function(...) {
+      "Bonjour le Monde!"
+    }
+  ))
+  with_mock("pkgapi::translator" = mock_translator, {
+    expect_equal(
+      translator_translate("hello", package = "package", name = "name"),
+      "Bonjour le Monde!")
+  })
+  mockery::expect_args(mock_translator, 1, "name", "package")
 })

--- a/tests/testthat/test-translator.R
+++ b/tests/testthat/test-translator.R
@@ -99,3 +99,11 @@ test_that("translator get package", {
   res <- translator(package = "impossible_package")
   expect_identical(res, translators[[id]])
 })
+
+test_that("translate from another package", {
+  ## Force .onload from hello to be called to reigster translators
+  hello::hello("test")
+  expect_equal(
+    translator_translate("hello", language = "fr", package = "hello"),
+    "Bonjour le Monde!")
+})

--- a/tests/testthat/test-translator.R
+++ b/tests/testthat/test-translator.R
@@ -106,7 +106,7 @@ test_that("translate from another package", {
       "Bonjour le Monde!"
     }
   ))
-  with_mock("pkgapi::translator" = mock_translator, {
+  with_mock("traduire::translator" = mock_translator, {
     expect_equal(
       translator_translate("hello", package = "package", name = "name"),
       "Bonjour le Monde!")

--- a/traduire.Rproj
+++ b/traduire.Rproj
@@ -1,0 +1,19 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
It looks like the issue I saw hintr is a bug, I think. 

The issue is passing a package to `t_` does not pass the package to the translator. e.g. 
calling `t_("key", package = "hintr")` from hintr2 will look for the translations in hintr2.

Here is a test which recreates it, it uses the "hello" package from the inst dir. I'm not sure what the best way to make sure that this is installed? Or that it is visible to people that they need to install it.