### PR TITLE
Identify untranslated strings in linting

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Suggests:
     mockery,
     rmarkdown,
     testthat
-RoxygenNote: 7.0.0
+RoxygenNote: 7.1.1
 VignetteBuilder: knitr
 Language: en-GB
 URL: https://github.com/reside-ic/traduire

--- a/R/lint_report.R
+++ b/R/lint_report.R
@@ -50,9 +50,11 @@ lint_tags_html <- function() {
   lint_tags(list(
     EXPR = html_span("expr"),
     VALID = html_span("valid"),
+    POSSIBLE = html_span("possible"),
     UNKNOWN_KEY = html_span("warning-unknown-key"),
     UNKNOWN_DATA = html_span("warning-unknown-data"),
     MISSING_KEY = html_span("error-missing"),
     INTERPOLATION_UNUSED = html_span("error-interpolation-unused"),
-    INTERPOLATION_MISSING = html_span("error-interpolation-missing")))
+    INTERPOLATION_MISSING = html_span("error-interpolation-missing"),
+    BARE_STRING = html_span("warning-bare-string")))
 }

--- a/inst/report/style.css
+++ b/inst/report/style.css
@@ -70,11 +70,19 @@ span.valid {
     color: steelblue;
 }
 
+span.possible {
+    color: steelblue;
+}
+
 span.warning-unknown-key {
     color: orange;
 }
 
 span.warning-unknown-data {
+    color: orange;
+}
+
+span.warning-bare-string {
     color: orange;
 }
 

--- a/man/lint_translations.Rd
+++ b/man/lint_translations.Rd
@@ -14,7 +14,10 @@ lint_translations_package(root, language = NULL)
 character vector of file names and directory names - directory
 names are expanded (non-recursively) to find all \code{.R} files.}
 
-\item{obj}{A translator object.}
+\item{obj}{A translator object, or `NULL`. If `NULL`, then the
+report will indicate only strings that might be translated vs
+bare strings, rather than check the likely success of
+translation.}
 
 \item{language}{Optional language to use as the language to lint.
 Each language must be at present linted separately}

--- a/tests/testthat/test-lint-report.R
+++ b/tests/testthat/test-lint-report.R
@@ -14,7 +14,8 @@ test_that("html span", {
 test_that("report for file", {
   src <- c(
     'a <- t_("hello")',
-    'b <- t_("missing")')
+    'b <- t_("missing")',
+    'f("some string")')
   p <- tempfile()
   dir.create(p)
   writeLines(src, file.path(p, "a.R"))
@@ -35,10 +36,13 @@ test_that("report for file", {
   spans <- strsplit(trimws(code), "\n", fixed = TRUE)[[1]]
   expect_equal(
     spans[[1]],
-    '<span class="line"></span>a &lt;- <span class="valid"><span class="expr">t_("hello")</span></span>')
+    '<span class="line"></span>a &lt;- <span class="valid" data-tooltip="hello world"><span class="expr">t_("hello")</span></span>')
   expect_equal(
     spans[[2]],
     '<span class="line"></span>b &lt;- <span class="expr">t_(<span class="error-missing" data-tooltip="Translation key \'translation:missing\' not found">"missing"</span>)</span>')
+  expect_equal(
+    spans[[3]],
+    '<span class="line"></span>f(<span class="warning-bare-string"><span class="expr">"some string"</span></span>)')
 })
 
 

--- a/tests/testthat/test-lint.R
+++ b/tests/testthat/test-lint.R
@@ -239,3 +239,24 @@ test_that("lint tags", {
     lint_tags(list(EXPR = html_span("whatever"))),
     "Invalid tag names")
 })
+
+
+test_that("Identify bare strings", {
+  code <- c(
+    'a <- t_("hello")', # this string is ok
+    'x <- "bad string"', # not ok, a bare string
+    'f <- function(x) {',
+    '  a(b(c("deeply bad string")))',
+    '}')
+  p <- tempfile()
+  writeLines(code, p)
+  on.exit(unlink(p))
+  res <- lint_translations(p, NULL)
+
+  expect_length(res[[1]]$usage, 1)
+  expect_equal(res[[1]]$usage[[1]]$key$key, "hello")
+
+  expect_length(res[[1]]$strings, 2)
+  expect_equal(res[[1]]$strings[[1]]$value, "bad string")
+  expect_equal(res[[1]]$strings[[2]]$value, "deeply bad string")
+})


### PR DESCRIPTION
This does basic string identification on linting. It also makes the linting a bit more accessible by allowing the translation object to be `NULL`, which will be a good starting point for most people

Fixes RESIDE-76