### PR TITLE
Add resources as explicit arg of translator_register and add additional test

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: traduire
 Title: Example Translation in a Package
-Version: 0.0.5
+Version: 0.0.6
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/R/translator.R
+++ b/R/translator.R
@@ -57,6 +57,8 @@
 ##'
 ##' @title Register a translator
 ##'
+##' @inheritParams i18n
+##' 
 ##' @param ... For \code{translator_register}, arguments passed to
 ##'   \code{\link{traduire_options}} to build the translator object.  All
 ##'   arguments are accepted.  For \code{translator_translate} and
@@ -85,9 +87,9 @@
 ##' traduire::t_("hello", language = "fr", name = "myexample")
 ##' "myexample" %in% traduire::translator_list()
 ##' traduire::translator_unregister("myexample")
-translator_register <- function(..., name = NULL) {
+translator_register <- function(resources, ..., name = NULL) {
   name <- name_from_context(name, NULL, strict = TRUE)
-  translators[[name]] <- i18n(...)
+  translators[[name]] <- i18n(resources = resources, ...)
 }
 
 

--- a/man/translator.Rd
+++ b/man/translator.Rd
@@ -10,7 +10,7 @@
 \alias{translator_list}
 \title{Register a translator}
 \usage{
-translator_register(..., name = NULL)
+translator_register(resources, ..., name = NULL)
 
 translator_unregister(name = NULL)
 
@@ -25,6 +25,11 @@ translator_set_language(language, name = NULL, package = NULL)
 translator_list()
 }
 \arguments{
+\item{resources}{Path to a json file containing translation
+resources. If given in this way, then on-demand translation
+loading (via \code{resource_pattern}) is disabled unless a
+currently unexposed i18next option is used.}
+
 \item{...}{For \code{translator_register}, arguments passed to
 \code{\link{traduire_options}} to build the translator object.  All
 arguments are accepted.  For \code{translator_translate} and

--- a/tests/testthat/test-translator.R
+++ b/tests/testthat/test-translator.R
@@ -113,3 +113,29 @@ test_that("translate from another package", {
   })
   mockery::expect_args(mock_translator, 1, "name", "package")
 })
+
+
+test_that("translator registered with resource_pattern", {
+  root <- traduire_file("examples/structured")
+  name <- rand_str()
+  res <- translator_register(
+    NULL,
+    name = name,
+    resource_pattern = sprintf("%s/{language}-{namespace}.json", root),
+    default_namespace = "common",
+    namespaces = c("common", "login"),
+    language = "en",
+    languages = c("en", "fr"))
+  expect_is(res, "i18n")
+  expect_true(name %in% translator_list())
+  
+  expect_identical(translator(name), res)
+  expect_equal(translator_translate("hello", language = "fr", name = name),
+               "salut le monde")
+  expect_equal(t_("hello", language = "fr", name = name),
+               "salut le monde")
+  expect_true(exists(name, translators))
+  translator_unregister(name)
+  expect_false(exists(name, translators))
+  expect_false(name %in% translator_list())
+})


### PR DESCRIPTION
This PR will
* Add a test of setting up a translator like we do in hint (using `resource_pattern`)
* Add `resources` as an arg to `translator_register` - this has to exist so expose it in function arg for clarity

Talked a bit about `resources` and `resource_pattern` being together but on looking more, if you use `resource_pattern` then other args like `languages` and `namespaces` need to be set. So I think we need to tidy this up but I will make a ticket and leave this for now. https://mrc-ide.myjetbrains.com/youtrack/issue/RESIDE-226