### PR TITLE
reside-94: Truncate long files in translation lint report

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: traduire
 Title: Example Translation in a Package
-Version: 0.0.6
+Version: 0.0.7
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",

--- a/R/lint_report.R
+++ b/R/lint_report.R
@@ -20,10 +20,9 @@ lint_translations_html_report <- function(x) {
 
 lint_translations_html_report_file <- function(x) {
   ans <- x$info$render(lint_tags_html(), escape = TRUE, filter = TRUE)
-  browser()
   fmt <- '<div id="%s" class="tabcontent">\n<pre>\n%s\n</pre>\n</div>'
   code <- sprintf('<span class="line" line-number="%s"></span>%s', 
-                  ans$lines, ans$text)
+                  ans$line_labels, ans$text)
   tab <- sprintf(
     '<button class="tablinks" onclick="openTab(event, \'%s\')">%s</button>',
     x$path, x$path)

--- a/R/lint_report.R
+++ b/R/lint_report.R
@@ -19,9 +19,11 @@ lint_translations_html_report <- function(x) {
 
 
 lint_translations_html_report_file <- function(x) {
-  ans <- x$info$render(lint_tags_html(), escape = TRUE, filter = FALSE)
+  ans <- x$info$render(lint_tags_html(), escape = TRUE, filter = TRUE)
+  browser()
   fmt <- '<div id="%s" class="tabcontent">\n<pre>\n%s\n</pre>\n</div>'
-  code <- sprintf('<span class="line"></span>%s', ans$text)
+  code <- sprintf('<span class="line" line-number="%s"></span>%s', 
+                  ans$lines, ans$text)
   tab <- sprintf(
     '<button class="tablinks" onclick="openTab(event, \'%s\')">%s</button>',
     x$path, x$path)

--- a/R/string.R
+++ b/R/string.R
@@ -117,9 +117,16 @@ markup_render <- function(tags, spans, text, filter = TRUE, group = NULL,
   messages <- data_frame(tag = tag[i], line = line[i], value = msg[i])
 
   if (filter) {
+    browser()
+    lines <- unique(line)
+    max_length <- length(text)
+    lines <- vapply(lines, function(l) {
+      lower <- max(1, l - 5) ## Can't include line less than line 1
+      upper <- min(max_length, l + 5) ## Can't go beyond last line
+      c(lower, upper)
+    })
     lines <- min(line):max(line)
     text <- text[lines]
-    messages$index <- messages$line - lines[[1]] + 1L
   } else {
     lines <- seq_along(text)
   }

--- a/R/string.R
+++ b/R/string.R
@@ -116,22 +116,28 @@ markup_render <- function(tags, spans, text, filter = TRUE, group = NULL,
   i <- !is.na(msg)
   messages <- data_frame(tag = tag[i], line = line[i], value = msg[i])
 
-  if (filter) {
-    browser()
-    lines <- unique(line)
-    max_length <- length(text)
+  lines <- unique(line)
+  max_length <- length(text)
+  if (length(lines) == 0) {
+    ## There are no "interesting" lines so default to showing 5
+    page <- select_text(text, cbind(c(1, min(max_length, 5))), max_length)
+    line_labels <- page$line_labels
+    text <- page$text
+  } else if (filter) {
     lines <- vapply(lines, function(l) {
-      lower <- max(1, l - 5) ## Can't include line less than line 1
-      upper <- min(max_length, l + 5) ## Can't go beyond last line
+      lower <- max(1L, as.integer(l) - 5L) ## Can't include line before line 1
+      upper <- min(max_length, as.integer(l) + 5L) ## Can't go beyond last line
       c(lower, upper)
-    })
-    lines <- min(line):max(line)
-    text <- text[lines]
+    }, integer(2))
+    lines <- union_intervals(lines)
+    page <- select_text(text, lines, max_length)
+    line_labels <- page$line_labels
+    text <- page$text
   } else {
-    lines <- seq_along(text)
+    line_labels <- seq_along(text)
   }
 
-  list(lines = lines, text = text, messages = messages)
+  list(line_labels = line_labels, text = text, messages = messages)
 }
 
 
@@ -160,4 +166,64 @@ html_escape <- function(text, line, col, open) {
   }
 
   list(text = text, col = col)
+}
+
+## Note intervals must be ordered before this can be used
+## for unioning. By ordered for a set of intervals
+## (a1, b1), (a2, b2), .. (an, bn)
+## It must be that a(i) <= b(i) for all i in 1,...n
+## and a(i) <= a(i+1) for all i in 1,..(n-1)
+IntervalStack <- R6::R6Class(
+  "IntervalStack",
+  cloneable = FALSE,
+  public = list(
+    stack = NULL,
+    length = NULL,
+    push = function(interval) {
+      if (is.null(self$length)) {
+        self$stack <- matrix(interval)
+        self$length <- 1
+      } else {
+        last_interval <- self$stack[, self$length]
+        ## All intervals are closed so we compare with interval + 1 for the case
+        ## e.g. intervals [1, 2], [3, 4] this should return [1, 4]
+        if (last_interval[2] + 1 < interval[1]) {
+          self$stack <- unname(cbind(self$stack, interval))
+          self$length <- self$length + 1
+        } else {
+          new_interval <- c(last_interval[1], 
+                            max(last_interval[2], interval[2]))
+          self$stack <- unname(cbind(self$stack[, -(self$length)], 
+                                     new_interval))
+        }
+      }
+    }
+  )
+)
+
+union_intervals <- function(intervals) {
+  ordered <- intervals[, order(intervals[1, ]), drop = FALSE]
+  unioned <- IntervalStack$new()
+  for (i in seq.int(ncol(ordered))) {
+    unioned$push(ordered[, i])
+  }
+  unioned$stack
+}
+
+select_text <- function(text, lines, max_length) {
+  connector_line <- "..."
+  sections <- lapply(seq.int(ncol(lines)), function(i) {
+    interval <- lines[, i]
+    section_lines <- seq.int(interval[1], interval[2])
+    section <- text[section_lines]
+    if (interval[2] != max_length) {
+      ## Interval has ended before the end of the document, so add a line break
+      section <- c(section, connector_line)
+      section_lines <- c(section_lines, "...")
+    }
+    list(section = section,
+         line_labels = section_lines)
+  })
+  list(text = unlist(lapply(sections, "[[", "section")),
+       line_labels = unlist(lapply(sections, "[[", "line_labels")))
 }

--- a/inst/report/style.css
+++ b/inst/report/style.css
@@ -44,12 +44,8 @@ pre {
     color: #777;
 }
 
-span.line {
-    counter-increment: line;
-}
-
 span.line::before {
-    content: counter(line);
+    content: attr(line-number);
     display: inline-block;
     width: 2em;
     border-right: 1px solid #ddd;

--- a/tests/testthat/test-lint-report.R
+++ b/tests/testthat/test-lint-report.R
@@ -97,3 +97,42 @@ test_that("lint_translations_package corner cases", {
     lint_translations_package(path),
     "Invalid DESCRIPTION")
 })
+
+test_that("long files are truncated", {
+  src <- c(
+    'a <- t_("hello")',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'b <- "string multiple',
+    ' lines)"',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2',
+    'a <- 2')
+  p <- tempfile()
+  dir.create(p)
+  writeLines(src, file.path(p, "a.R"))
+  obj <- i18n(traduire_file("examples/simple.json"))
+  x <- lint_translations("a.R", obj, root = p)
+  res <- lint_translations_html_report(x)
+  
+  t <- tempfile(fileext = ".html")
+  writeLines(res, t)
+  browse_html(res)
+})
+  

--- a/tests/testthat/test-lint-report.R
+++ b/tests/testthat/test-lint-report.R
@@ -36,13 +36,13 @@ test_that("report for file", {
   spans <- strsplit(trimws(code), "\n", fixed = TRUE)[[1]]
   expect_equal(
     spans[[1]],
-    '<span class="line"></span>a &lt;- <span class="valid" data-tooltip="hello world"><span class="expr">t_("hello")</span></span>')
+    '<span class="line" line-number="1"></span>a &lt;- <span class="valid" data-tooltip="hello world"><span class="expr">t_("hello")</span></span>')
   expect_equal(
     spans[[2]],
-    '<span class="line"></span>b &lt;- <span class="expr">t_(<span class="error-missing" data-tooltip="Translation key \'translation:missing\' not found">"missing"</span>)</span>')
+    '<span class="line" line-number="2"></span>b &lt;- <span class="expr">t_(<span class="error-missing" data-tooltip="Translation key \'translation:missing\' not found">"missing"</span>)</span>')
   expect_equal(
     spans[[3]],
-    '<span class="line"></span>f(<span class="warning-bare-string"><span class="expr">"some string"</span></span>)')
+    '<span class="line" line-number="3"></span>f(<span class="warning-bare-string"><span class="expr">"some string"</span></span>)')
 })
 
 
@@ -101,29 +101,10 @@ test_that("lint_translations_package corner cases", {
 test_that("long files are truncated", {
   src <- c(
     'a <- t_("hello")',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
+    rep('a <- 2', 15),
     'b <- "string multiple',
     ' lines)"',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2',
-    'a <- 2')
+    rep('a <- 2', 10))
   p <- tempfile()
   dir.create(p)
   writeLines(src, file.path(p, "a.R"))
@@ -131,8 +112,51 @@ test_that("long files are truncated", {
   x <- lint_translations("a.R", obj, root = p)
   res <- lint_translations_html_report(x)
   
-  t <- tempfile(fileext = ".html")
-  writeLines(res, t)
-  browse_html(res)
+  ## 2 lines are skip lines
+  re <- '<span class=\"line\" line-number=\"...\"></span>...'
+  expect_match(res, re)
+  occurances <- gregexpr(re, res)
+  expect_length(occurances[[1]], 2)
+  ## Final line is a skip line
+  re <- '<span class=\"line\" line-number=\"...\"></span>...\n</pre>'
+  expect_match(res, re)
+  occurances <- gregexpr(re, res)
+  expect_length(occurances[[1]], 1)
+})
+
+test_that("short files with no interesting lines displays all lines", {
+  src <- c("a <- 1", "b <- 2")
+  p <- tempfile()
+  dir.create(p)
+  writeLines(src, file.path(p, "a.R"))
+  obj <- i18n(traduire_file("examples/simple.json"))
+  x <- lint_translations("a.R", obj, root = p)
+  res <- lint_translations_html_report(x)
+  
+  ## 2 lines of content shown
+  re <- '<span class=\"line\" line-number=\"1\"></span>...'
+  expect_match(res, re)
+  re <- '<span class=\"line\" line-number=\"2\"></span>...'
+  expect_match(res, re)
+  re <- '<span class=\"line\" line-number=\"3\"></span>...'
+  expect_false(grepl(re, res))
+})
+
+test_that("files with no interesting lines are truncated", {
+  src <- c(rep("a <- 1", 10))
+  p <- tempfile()
+  dir.create(p)
+  writeLines(src, file.path(p, "a.R"))
+  obj <- i18n(traduire_file("examples/simple.json"))
+  x <- lint_translations("a.R", obj, root = p)
+  res <- lint_translations_html_report(x)
+  
+  ## 5 lines of content shown
+  re <- '<span class=\"line\" line-number=\"1\"></span>...'
+  expect_match(res, re)
+  re <- '<span class=\"line\" line-number=\"5\"></span>...'
+  expect_match(res, re)
+  re <- '<span class=\"line\" line-number=\"6\"></span>...'
+  expect_false(grepl(re, res))
 })
   


### PR DESCRIPTION
![Selection_121](https://user-images.githubusercontent.com/39248272/131522869-ecff84d8-f684-4415-89da-d8b0399fadfe.png)
Now looks like this - let me know if you want to do anything fancier with styling. Starting looking at colouring the line skipped blue - kind of like github does but I think would require bigger changes (like changing the code to be in a table which would break all the current styling)