### PR TITLE
Use glue_data when data is a list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: traduire
 Title: Internationalisation on the Fly
-Version: 0.1.0
+Version: 0.1.1
 Authors@R:
     c(person(given = "Rich",
              family = "FitzJohn",
@@ -18,7 +18,7 @@ Encoding: UTF-8
 Imports:
     V8,
     R6,
-    glue
+    glue (>= 1.8.0)
 Suggests:
     jsonlite,
     knitr,

--- a/R/i18n.R
+++ b/R/i18n.R
@@ -176,7 +176,7 @@ i18n_backend_read <- function(pattern, language, namespace) {
     return(jsonlite::unbox("null"))
   }
   data <- list(language = language, namespace = namespace)
-  path <- glue::glue(pattern, .envir = data)
+  path <- glue::glue_data(data, pattern)
   tryCatch(
     read_input(path),
     error = function(e) {

--- a/R/lint_report.R
+++ b/R/lint_report.R
@@ -14,7 +14,7 @@ lint_translations_html_report <- function(x) {
   d <- list(title = title, style = style, script = script,
             tabs = tabs, content = content)
 
-  unclass(glue::glue(template, .envir = d))
+  unclass(glue::glue_data(d, template))
 }
 
 


### PR DESCRIPTION
This changed in https://github.com/tidyverse/glue/issues/317 and has now been released in current CRAN version of glue causing fairly confusing downstream failures.

e.g. in Naomi
```
Error: Error: .onLoad failed in loadNamespace() for 'naomi', details:
  call: NULL
  error: is.environment(.envir) is not TRUE
```